### PR TITLE
Fix includes path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ PowerShell post-installation script to minimize and customize Windows operating 
 ## INSTALL AND USAGE
 * Make sure that the requirements (see REQUIREMENTS) are fulfilled
 * Download a zip file and uncompress it
-* Adjust the settings and variables in section of the script to your environment and requirements. All existing scripts in the include directory will be executed, 
+* Adjust the settings and variables in section of the script to your environment and requirements. All existing scripts in the include directory will be executed,
   * unless you explicitly define it as excluded,
   * Alternatively, actions in the include directory that are not needed or desired can simply be deleted.
+* The script locates the `includes` folder relative to its own path, so keep the directory structure intact.
 * Start the PowerShell script using ```.\customize-windows-client.ps1```
 * If ExecutionPolicy is restricted try to use: ```powershell -ExecutionPolicy Bypass .\customize-windows-client.ps1```
 

--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -36,6 +36,11 @@ $BLANK = " "
 $TIME = Get-Date -UFormat "%A %d.%m.%Y %R"
 $FOREGROUNDCOLOR = "Yellow"
 
+# Determine script and includes directory. The script looks for the 'includes'
+# folder relative to its own location.
+$ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$IncludesPath = Join-Path $ScriptRoot 'includes'
+
 # Define actions should be excluded
 $Excludes = @(
     "Disable-Administrator-Description.ps1";
@@ -85,7 +90,7 @@ Write-Host ($CR +"This system will customized and minimized") -foregroundcolor $
 $confirmation = Read-Host "Are you sure you want to proceed? [press: y]"
 if ($confirmation -eq 'y') {
     # Create array of actions out of include folder
-    $Actions = @((Get-ChildItem -Path 'includes').Name)
+    $Actions = Get-ChildItem -Path $IncludesPath | Select-Object -ExpandProperty Name
 
     # Delete excluded actions out of action-array
     $Actions = $Actions |Where-Object { $Excludes -notcontains $_ }
@@ -95,7 +100,7 @@ if ($confirmation -eq 'y') {
         Write-Host "Execute " -NoNewline
         Write-Host ("$Action") -foregroundcolor Yellow -NoNewline
         Write-Host " ..."
-        & "includes\$Action"
+        & (Join-Path $IncludesPath $Action)
     }
 }
 


### PR DESCRIPTION
## Summary
- compute script and includes path in PowerShell script
- search for include scripts using the new path
- execute actions using explicit Join-Path
- document the relative includes folder in README

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403021e19c83329dd0c7fbca3dd3e8