### PR TITLE
Enhance renaming and workgroup includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ PowerShell post-installation script to minimize and customize Windows operating 
   * unless you explicitly define it as excluded,
   * Alternatively, actions in the include directory that are not needed or desired can simply be deleted.
 * The script locates the `includes` folder relative to its own path, so keep the directory structure intact.
+* Host renaming and joining a workgroup are handled by separate include scripts
+  (`Rename-Computer.ps1` and `Join-Workgroup.ps1`). Each script displays the
+  current value and asks if it should be changed. Add their filenames to
+  `$Excludes` if you want to skip either action.
 * Start the PowerShell script using ```.\customize-windows-client.ps1```
 * If ExecutionPolicy is restricted try to use: ```powershell -ExecutionPolicy Bypass .\customize-windows-client.ps1```
 

--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -19,8 +19,6 @@ https://github.com/filipnet/customize-windows-client
 #>
  
 # Variables
-$HOSTNAME = "win10client"
-$WORKGROUP = "WORKGROUP"
 $DRIVELABELSYS = "OS"
 $TEMPFOLDER = "C:\Temp"
 $INSTALLFOLDER = "C:\Install"
@@ -104,23 +102,7 @@ if ($confirmation -eq 'y') {
     }
 }
 
-# Start renaming client
-Write-Host ($CR +"Hostname and workgroup will be changed") -foregroundcolor $FOREGROUNDCOLOR $CR
-$confirmation = Read-Host "Are you sure you want to change it? [press: y]"
-if ($confirmation -eq 'y') {
-    # Set hostname and workgroup
-    Try {
-        Rename-Computer -NewName $HOSTNAME -ErrorAction Stop
-    } Catch {
-        Write-Warning $Error[0]
-    }
-    Try {
-        Add-Computer -WorkgroupName $WORKGROUP -ErrorAction Stop
-    } Catch {
-        Write-Warning $Error[0]
-    }
-    Write-Host ("Server renamed to $HOSTNAME and joined to workgroup $WORKGROUP") -foregroundcolor $FOREGROUNDCOLOR $CR 
-}
+
 
 # Restart to apply all changes
 Write-Host ($CR +"This system will restart to apply all changes") -foregroundcolor $FOREGROUNDCOLOR $CR 

--- a/includes/Join-Workgroup.ps1
+++ b/includes/Join-Workgroup.ps1
@@ -1,0 +1,17 @@
+# Display the current workgroup and ask whether it should be changed
+$CurrentWorkgroup = (Get-WmiObject Win32_ComputerSystem).Workgroup
+Write-Host ($CR + "Current workgroup: $CurrentWorkgroup") -foregroundcolor $FOREGROUNDCOLOR
+$confirmation = Read-Host "Do you want to change the workgroup? [y/N]"
+if ($confirmation -eq 'y') {
+    $WORKGROUP = Read-Host "Enter new workgroup"
+
+    Write-Host ($CR + "Join to workgroup") -foregroundcolor $FOREGROUNDCOLOR $CR
+    Try {
+        Add-Computer -WorkgroupName $WORKGROUP -ErrorAction Stop
+    } Catch {
+        Write-Warning $Error[0]
+    }
+    Write-Host ("Joined to workgroup $WORKGROUP") -foregroundcolor $FOREGROUNDCOLOR $CR
+} else {
+    Write-Host "Workgroup change skipped." -foregroundcolor $FOREGROUNDCOLOR $CR
+}

--- a/includes/Rename-Computer.ps1
+++ b/includes/Rename-Computer.ps1
@@ -1,0 +1,17 @@
+# Display the current computer name and ask whether it should be changed
+$CurrentName = $env:COMPUTERNAME
+Write-Host ($CR + "Current computer name: $CurrentName") -foregroundcolor $FOREGROUNDCOLOR
+$confirmation = Read-Host "Do you want to change the computer name? [y/N]"
+if ($confirmation -eq 'y') {
+    $HOSTNAME = Read-Host "Enter new computer name"
+
+    Write-Host ($CR + "Hostname will be changed") -foregroundcolor $FOREGROUNDCOLOR $CR
+    Try {
+        Rename-Computer -NewName $HOSTNAME -ErrorAction Stop
+    } Catch {
+        Write-Warning $Error[0]
+    }
+    Write-Host ("Server renamed to $HOSTNAME") -foregroundcolor $FOREGROUNDCOLOR $CR
+} else {
+    Write-Host "Hostname change skipped." -foregroundcolor $FOREGROUNDCOLOR $CR
+}


### PR DESCRIPTION
## Summary
- show the current name or workgroup before prompting
- allow skipping renaming and joining
- document prompts in README

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403171aed8833288ad4fdf7807e370