### PR TITLE
Split hibernation and display timeout modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ PowerShell post-installation script to minimize and customize Windows operating 
 * Download a zip file and uncompress it
 * Adjust the settings and variables in section of the script to your environment and requirements. All scripts in the `includes` directory will be executed.
   * To disable a customization action, move its script into `includes/disabled` or delete it.
+* Note: `Disable-Display-Sleep-Mode-Timeouts.ps1` and `Set-PowerManagement-HighPerformance.ps1` should not both be active because their settings may conflict.
 * The script locates the `includes` folder relative to its own path, so keep the directory structure intact.
 * Host renaming and joining a workgroup are handled by separate include scripts
   (`Rename-Computer.ps1` and `Join-Workgroup.ps1`). Each script displays the

--- a/includes/Disable-Display-Sleep-Mode-Timeouts-Hibernation.ps1
+++ b/includes/Disable-Display-Sleep-Mode-Timeouts-Hibernation.ps1
@@ -1,9 +1,0 @@
-# Disable display and sleep mode timeouts
-powercfg /X monitor-timeout-ac 0
-powercfg /X monitor-timeout-dc 0
-powercfg /X standby-timeout-ac 0
-powercfg /X standby-timeout-dc 0
-
-# Disable hibernation (reclaims disk space, avoids hybrid sleep issues)
-powercfg -h off
-Write-Host "✅ Hibernation disabled to prevent hybrid sleep and reclaim disk space."

--- a/includes/Disable-Hibernation.ps1
+++ b/includes/Disable-Hibernation.ps1
@@ -1,0 +1,3 @@
+# Disable hibernation (reclaims disk space, avoids hybrid sleep issues)
+powercfg -h off
+Write-Host "✅ Hibernation disabled to prevent hybrid sleep and reclaim disk space."

--- a/includes/disabled/Disable-Display-Sleep-Mode-Timeouts.ps1
+++ b/includes/disabled/Disable-Display-Sleep-Mode-Timeouts.ps1
@@ -1,0 +1,6 @@
+# Disable display and sleep mode timeouts
+# Note: Use either this script or Set-PowerManagement-HighPerformance.ps1, not both, as they could conflict.
+powercfg /X monitor-timeout-ac 0
+powercfg /X monitor-timeout-dc 0
+powercfg /X standby-timeout-ac 0
+powercfg /X standby-timeout-dc 0

--- a/includes/disabled/Set-PowerManagement-HighPerformance.ps1
+++ b/includes/disabled/Set-PowerManagement-HighPerformance.ps1
@@ -1,3 +1,4 @@
+# Note: Use either this script or Disable-Display-Sleep-Mode-Timeouts.ps1, not both, as they could conflict.
 # Set Power Management to High Performance if it is not currently the active plan
  Try {
     $highPerf = powercfg -l | ForEach-Object{if($_.contains($POWERMANAGEMENT)) {$_.split()[3]}}


### PR DESCRIPTION
## Summary
- separate hibernation settings into their own script
- disable the display/sleep timeout module by default
- add usage warning comments for power-management modules
- document the potential conflict in README

## Testing
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840361394848332b59ad704d46e9654