### PR TITLE
Remove placeholder wallpaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ PowerShell post-installation script to minimize and customize Windows operating 
   (`Rename-Computer.ps1` and `Join-Workgroup.ps1`). Each script displays the
   current value and asks if it should be changed. Add their filenames to
   `$Excludes` if you want to skip either action.
+* `Set-WallpaperWithStats.ps1` sets a desktop wallpaper from the `wallpaper` folder and overlays basic PC information on the image. Add your own image to that folder and update the script's `$wallpaperImage` path to point to it.
 * Start the PowerShell script using ```.\customize-windows-client.ps1```
 * If ExecutionPolicy is restricted try to use: ```powershell -ExecutionPolicy Bypass .\customize-windows-client.ps1```
 

--- a/includes/Set-WallpaperWithStats.ps1
+++ b/includes/Set-WallpaperWithStats.ps1
@@ -1,0 +1,43 @@
+# Set a custom wallpaper and overlay system information on the image
+
+# Determine repository root based on this script's location
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot  = Split-Path $scriptDir -Parent
+
+# Path to wallpaper image relative to repo root.
+# Update the filename to match the image you add to the `wallpaper` folder.
+$wallpaperImage = Join-Path $repoRoot 'wallpaper\wallpaper.png'
+
+if (-not (Test-Path $wallpaperImage)) {
+    Write-Host "Wallpaper file not found: $wallpaperImage" -ForegroundColor Yellow
+    return
+}
+
+# Gather system information
+$computerName  = $env:COMPUTERNAME
+$workgroup     = (Get-CimInstance Win32_ComputerSystem).Workgroup
+$windowsVer    = (Get-CimInstance Win32_OperatingSystem).Caption
+
+# Load image and overlay text
+Add-Type -AssemblyName System.Drawing
+$image     = [System.Drawing.Image]::FromFile($wallpaperImage)
+$graphics  = [System.Drawing.Graphics]::FromImage($image)
+$font      = New-Object System.Drawing.Font('Arial',14)
+$brush     = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::Yellow)
+
+$infoText  = "PC: $computerName`nWorkgroup: $workgroup`nWindows: $windowsVer"
+$graphics.DrawString($infoText,$font,$brush,10,10)
+
+# Save the temporary bitmap (wallpaper must be BMP format)
+$tempBmp   = Join-Path $env:TEMP 'wallpaper-with-stats.bmp'
+$image.Save($tempBmp, [System.Drawing.Imaging.ImageFormat]::Bmp)
+
+# Clean up objects
+$graphics.Dispose()
+$image.Dispose()
+$brush.Dispose()
+$font.Dispose()
+
+# Apply the new wallpaper
+Set-ItemProperty -Path 'HKCU:\Control Panel\Desktop' -Name Wallpaper -Value $tempBmp
+rundll32.exe user32.dll,UpdatePerUserSystemParameters

--- a/wallpaper/README.md
+++ b/wallpaper/README.md
@@ -1,0 +1,2 @@
+Place your wallpaper image in this directory and update the filename in `Set-WallpaperWithStats.ps1`.
+No placeholder file is included by default.


### PR DESCRIPTION
## Summary
- remove example image from `wallpaper/`
- update wallpaper docs to explain there is no placeholder image
- clarify wallpaper customization step in README
- point wallpaper script to `wallpaper.png` placeholder path

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: pwsh not found)*
- `powershell -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: powershell not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403d8d2c9c8332b5f3e8f48ffb5497