### PR TITLE
Enable Num Lock on startup

### DIFF
--- a/includes/Enable-NumLock.ps1
+++ b/includes/Enable-NumLock.ps1
@@ -1,0 +1,3 @@
+# Enable Num Lock by default for all users
+Set-ItemProperty -Path "HKCU:\Control Panel\Keyboard" -Name "InitialKeyboardIndicators" -Type String -Value "2"
+Set-ItemProperty -Path "Registry::HKEY_USERS\.DEFAULT\Control Panel\Keyboard" -Name "InitialKeyboardIndicators" -Type String -Value "2"


### PR DESCRIPTION
## Summary
- add `Enable-NumLock.ps1` to set Num Lock on by default

## Testing
- `powershell` or `pwsh` not available in container

------
https://chatgpt.com/codex/tasks/task_e_684046267fbc8332b768cede4447856f