### PR TITLE
Improve Microsoft account disable script

### DIFF
--- a/includes/Disable-MicrosoftAccount.ps1
+++ b/includes/Disable-MicrosoftAccount.ps1
@@ -1,5 +1,61 @@
+# Disable Microsoft account sign-in prompts and account creation
+
+# Check if the current profile is associated with a Microsoft account
+$identitiesPath = 'HKCU:\SOFTWARE\Microsoft\IdentityCRL\StoredIdentities'
+$identityFound = Test-Path $identitiesPath
+
+# Determine the domain for the current user. Microsoft accounts show the domain
+# value "MicrosoftAccount" instead of the computer name.
+$currentUser = Get-CimInstance Win32_UserAccount -Filter "Name='$env:USERNAME'" -ErrorAction SilentlyContinue
+$domainIsMicrosoft = $currentUser -and $currentUser.Domain -eq 'MicrosoftAccount'
+
+# Consider the user a Microsoft account if either the registry or domain check matches
+$hasMicrosoftAccount = $identityFound -or $domainIsMicrosoft
+
+# Detect if any enabled local accounts exist besides the built-ins
+$localAccounts = Get-CimInstance Win32_UserAccount -Filter "LocalAccount=true AND Disabled=false" -ErrorAction SilentlyContinue
+$filteredAccounts = $localAccounts | Where-Object {
+    $_.Name -notin @('Administrator','DefaultAccount','Guest','WDAGUtilityAccount')
+}
+
+# Determine whether any extra local accounts exist
+$hasLocalAccount = ($filteredAccounts | Measure-Object).Count -gt 0
+
+if ($hasMicrosoftAccount) {
+    Write-Warning 'A Microsoft account is detected. Disabling it may lock you out.'
+
+    if ($hasLocalAccount) {
+        Write-Host 'Local accounts detected:'
+        $filteredAccounts | ForEach-Object { Write-Host " - $($_.Name)" }
+    }
+    else {
+        Write-Warning 'No additional local accounts were found.'
+        $create = Read-Host 'Would you like to create a local account now? [y/N]'
+        if ($create -eq 'y') {
+            $username = Read-Host 'Enter a user name for the new account'
+            do {
+                $pw1 = Read-Host 'Enter password'
+                $pw2 = Read-Host 'Confirm password'
+                if ($pw1 -ne $pw2) {
+                    Write-Warning 'Passwords do not match. Please try again.'
+                }
+            } until ($pw1 -eq $pw2)
+            net user $username $pw1 /add
+            net localgroup Administrators $username /add
+            Write-Host "Created local administrator account '$username'."
+            $hasLocalAccount = $true
+        }
+    }
+
+    $confirmation = Read-Host 'Disable Microsoft account features? [y/N]'
+    if ($confirmation -ne 'y') {
+        Write-Host 'Microsoft account changes skipped.'
+        return
+    }
+}
+
 # Block Microsoft account sign-in prompts
-Write-Host "Blocking Microsoft account sign-in prompts..."
+Write-Host 'Blocking Microsoft account sign-in prompts...'
 reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v NoConnectedUser /t REG_DWORD /d 3 /f
 
 # Disable Microsoft account creation


### PR DESCRIPTION
## Summary
- warn and prompt before disabling Microsoft accounts
- offer to create a local admin account when none exist

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -Version 5.1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405f547964833292171c0443278316