### PR TITLE
Ensure Disable-MicrosoftAccount asks for confirmation

### DIFF
--- a/includes/Disable-MicrosoftAccount.ps1
+++ b/includes/Disable-MicrosoftAccount.ps1
@@ -52,6 +52,12 @@ if ($hasMicrosoftAccount) {
         Write-Host 'Microsoft account changes skipped.'
         return
     }
+} else {
+    $confirmation = Read-Host 'No Microsoft account detected. Disable Microsoft account features anyway? [y/N]'
+    if ($confirmation -ne 'y') {
+        Write-Host 'Microsoft account changes skipped.'
+        return
+    }
 }
 
 # Block Microsoft account sign-in prompts


### PR DESCRIPTION
## Summary
- add confirmation when no Microsoft account detected

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `powershell -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68406791fbe08332a03d4a621eeb06eb