### PR TITLE
Add one-liner for automated repo download

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ The project started as a fork of [filipnet/customize-windows-client](https://git
 - Run the script with administrative privileges
 
 ## Usage
-1. Download or clone this repository.
+1. Download or clone this repository. You can also run `download-repo.ps1` to automatically fetch and extract it.
+   To retrieve and invoke the script in one line, run:
+   ```powershell
+   powershell -NoProfile -ExecutionPolicy Bypass -Command "iwr -useb https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1 | iex"
+   ```
 2. Adjust variables near the top of `customize-windows-client.ps1` to suit your environment.
 3. Review the scripts in the `includes` folder. Delete or move any file to `includes/disabled` to skip that action.
 4. If using `Disable-MicrosoftAccount.ps1`, ensure a local administrator account exists and that you can sign in with it. This module blocks Microsoft account sign-in. To revert later, run:

--- a/download-repo.ps1
+++ b/download-repo.ps1
@@ -1,0 +1,57 @@
+# Download and extract the customize-windows-setup repository
+#
+# This script fetches the repository as a zip archive from GitHub,
+# extracts it to a folder next to the script and then removes the zip file.
+# Customize the $repoUrl if you need a different fork or branch.
+
+# URL of the zipped repository
+$repoUrl = "https://github.com/ShaheedFazal/customize-windows-setup/archive/refs/heads/main.zip"
+
+# Check for administrative privileges
+function Test-Administrator {
+    [OutputType([bool])]
+    param()
+    process {
+        [Security.Principal.WindowsPrincipal]$user = [Security.Principal.WindowsIdentity]::GetCurrent()
+        return $user.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+    }
+}
+
+if (-not (Test-Administrator)) {
+    Write-Warning "It is recommended to run this script as Administrator."
+}
+
+# Check execution policy
+try {
+    $executionPolicy = Get-ExecutionPolicy -Scope CurrentUser
+} catch {
+    $executionPolicy = $null
+    Write-Warning "Unable to determine execution policy: $_"
+}
+if ($executionPolicy -eq 'Restricted') {
+    Write-Warning "Script execution is disabled by the current policy ($executionPolicy)."
+    Write-Warning "Run 'Set-ExecutionPolicy RemoteSigned -Scope CurrentUser' or invoke the script with -ExecutionPolicy Bypass."
+}
+
+# Path to store the downloaded zip
+$zipPath = Join-Path $PSScriptRoot 'customize-windows-setup.zip'
+
+# Folder where the contents will be extracted
+$extractPath = Join-Path $PSScriptRoot 'customize-windows-setup'
+
+try {
+    Write-Host "Downloading repository..." -ForegroundColor Cyan
+    Invoke-WebRequest -Uri $repoUrl -OutFile $zipPath -UseBasicParsing
+
+    Write-Host "Extracting archive..." -ForegroundColor Cyan
+    if (Test-Path $extractPath) {
+        Remove-Item $extractPath -Recurse -Force
+    }
+    Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+
+    Write-Host "Cleaning up zip file..." -ForegroundColor Cyan
+    Remove-Item $zipPath
+    Write-Host "Done. Repository extracted to $extractPath" -ForegroundColor Green
+} catch {
+    Write-Host "An error occurred: $_" -ForegroundColor Red
+}


### PR DESCRIPTION
## Summary
- update usage instructions to show a one-liner that downloads and runs `download-repo.ps1`

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406b28217483328ca50245a010ee9d