### PR TITLE
Fix README one-liner quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ The project started as a fork of [filipnet/customize-windows-client](https://git
 - Run the script with administrative privileges
 
 ## Usage
-1. Download or clone this repository. You can also run `download-repo.ps1` to automatically fetch and extract it. To retrieve and invoke the script in one line, run (it saves the repository to your **Downloads** folder by default):
-   
+1. Download or clone this repository. You can also run `download-repo.ps1` to automatically fetch and extract it. To download and run the helper script in one step (which places everything in your **Downloads** folder), use:
+
    ```powershell
-   powershell -NoProfile -ExecutionPolicy Bypass -Command "$d = Join-Path $env:USERPROFILE 'Downloads'; iwr -Uri 'https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1' -OutFile (Join-Path $d 'download-repo.ps1')"
+   powershell -NoProfile -ExecutionPolicy Bypass -Command "$d = Join-Path $env:USERPROFILE 'Downloads'; iwr -Uri 'https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1' -OutFile (Join-Path $d 'download-repo.ps1'); & \`\"$d\\download-repo.ps1\`\""
    ```
 
    To download the repository **and** run `customize-windows-client.ps1` in one
    step, use:
 
    ```powershell
-   powershell -NoProfile -ExecutionPolicy Bypass -Command "iwr -useb https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1 | iex; & \"$env:USERPROFILE\Downloads\customize-windows-setup\customize-windows-setup-main\customize-windows-client.ps1\""
+   powershell -NoProfile -ExecutionPolicy Bypass -Command "iwr -useb https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1 | iex; & `"$env:USERPROFILE\Downloads\customize-windows-setup\customize-windows-setup-main\customize-windows-client.ps1`""
    ```
 
    **Caution:** Review the code before running the one line code to execute it.


### PR DESCRIPTION
## Summary
- escape double quotes in the README's one-line install command
- run download helper from the Downloads folder

## Testing
- `powershell -Command "$PSVersionTable"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840751366ac8332ad40a7222834a226