### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,37 +9,48 @@ The project started as a fork of [filipnet/customize-windows-client](https://git
 - Run the script with administrative privileges
 
 ## Usage
-1. Download or clone this repository. You can also run `download-repo.ps1` to automatically fetch and extract it. To download and run the helper script in one step (which places everything in your **Downloads** folder), use:
+1. **Open PowerShell as Administrator.** The script needs elevated privileges to modify system settings.
+2. **Allow script execution for this session.** Temporarily bypass the execution policy:
 
    ```powershell
-   Set-ExecutionPolicy Bypass -Scope Process -Force; $d = Join-Path $env:USERPROFILE 'Downloads'; iwr -Uri 'https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1' -OutFile (Join-Path $d 'download-repo.ps1'); & "$d\download-repo.ps1"
+   Set-ExecutionPolicy Bypass -Scope Process -Force
    ```
 
-   To download the repository **and** run `customize-windows-client.ps1` in one
-   step, use:
+3. **Download this repository.** Clone it manually or run `download-repo.ps1`, which fetches and extracts the archive for you. To retrieve and run the helper in one step (files go to your **Downloads** folder), run:
+
+   ```powershell
+   $d = Join-Path $env:USERPROFILE 'Downloads'; iwr -Uri 'https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1' -OutFile (Join-Path $d 'download-repo.ps1'); & "$d\download-repo.ps1"
+   ```
+
+   To download the repository **and** start `customize-windows-client.ps1` immediately, run:
 
    ```powershell
    powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iwr -useb https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1 | iex; & `"$env:USERPROFILE\Downloads\customize-windows-setup\customize-windows-setup-main\customize-windows-client.ps1`""
    ```
 
-   **Caution:** Review the code before running the one line code to execute it.
-   
-2. Adjust variables near the top of `customize-windows-client.ps1` to suit your environment.
-3. Review the scripts in the `includes` folder. Delete or move any file to `includes/disabled` to skip that action.
-4. If using `Disable-MicrosoftAccount.ps1`, ensure a local administrator account exists and that you can sign in with it. This module blocks Microsoft account sign-in. To revert later, run:
+   **Caution:** Review the code before running the one line command.
+
+4. Adjust variables near the top of `customize-windows-client.ps1` to suit your environment.
+5. Review the scripts in the `includes` folder. Delete or move any file to `includes/disabled` to skip that action.
+6. If using `Disable-MicrosoftAccount.ps1`, ensure a local administrator account exists and that you can sign in with it. This module blocks Microsoft account sign-in. To revert later, run:
    ```powershell
    reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v NoConnectedUser /t REG_DWORD /d 0 /f
    reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v BlockUserFromCreatingAccounts /t REG_DWORD /d 0 /f
    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\UserProfileEngagement" /v ScoobeSystemSettingEnabled /t REG_DWORD /d 1 /f
    ```
-5. Launch the script:
+7. **Run the script from the same console** so you can respond to prompts:
+
    ```powershell
    .\customize-windows-client.ps1
    ```
-   If the execution policy is restricted, start it with:
+
+   If the execution policy is still restricted, start it with:
+
    ```powershell
    powershell -ExecutionPolicy Bypass .\customize-windows-client.ps1
    ```
+
+   The script asks for confirmation before customizing Windows and again before rebooting. Press `y` and **Enter** when prompted.
 
 Each script in `includes` performs a single customization step—such as disabling Cortana, blocking Microsoft account sign-in and Windows Hello for Business, configuring Windows Update, or installing useful tools. `Set-WallpaperWithStats.ps1` can also set a wallpaper and overlay basic system information.
 


### PR DESCRIPTION
## Summary
- clarify that the setup script must run in an elevated PowerShell console
- add steps for temporarily bypassing script restrictions
- explain how to download the repo and run `customize-windows-client.ps1`
- note that users must confirm prompts during execution

## Testing
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684079ce2e388332b1920b8735abe69f