### PR TITLE
Add Start menu pin configuration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The project started as a fork of [filipnet/customize-windows-client](https://git
 
    The script asks for confirmation before customizing Windows and again before rebooting. Press `y` and **Enter** when prompted.
 
-Each script in `includes` performs a single customization step—such as disabling Cortana, blocking Microsoft account sign-in and Windows Hello for Business, configuring Windows Update, or installing useful tools. `Set-WallpaperWithStats.ps1` can also set a wallpaper and overlay basic system information.
+Each script in `includes` performs a single customization step—such as disabling Cortana, blocking Microsoft account sign-in and Windows Hello for Business, configuring Windows Update, or installing useful tools. `Configure-StartPins.ps1` resets pinned items to File Explorer, Google Chrome, Telegram and WhatsApp Web. `Set-WallpaperWithStats.ps1` can set a wallpaper and overlay basic system information.
 
 ## Contributing
 Contributions are welcome! New customization modules or improvements to existing scripts help keep this project useful for different environments.

--- a/includes/Configure-StartPins.ps1
+++ b/includes/Configure-StartPins.ps1
@@ -1,0 +1,54 @@
+# Configure pinned Start menu apps
+# Clears existing pins (except File Explorer) and pins Chrome, Telegram and WhatsApp Web.
+
+Write-Host "\xF0\x9F\x94\x8F Configuring Start menu pins..." -ForegroundColor Cyan
+
+# Locate Chrome executable for the WhatsApp Web shortcut
+$chromeExe = Get-Command "chrome.exe" -ErrorAction SilentlyContinue
+if (-not $chromeExe) {
+    $paths = 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe','C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe'
+    foreach ($p in $paths) { if (Test-Path $p) { $chromeExe = $p; break } }
+}
+if (-not $chromeExe) {
+    Write-Host "❌ Google Chrome not found. Skipping Start menu pin configuration." -ForegroundColor Red
+    return
+}
+
+# Create WhatsApp Web shortcut in the Start Menu if it doesn't exist
+$programs = [Environment]::GetFolderPath('Programs')
+$whatsAppLnk = Join-Path $programs 'WhatsApp Web.lnk'
+if (-not (Test-Path $whatsAppLnk)) {
+    $shell = New-Object -ComObject WScript.Shell
+    $shortcut = $shell.CreateShortcut($whatsAppLnk)
+    $shortcut.TargetPath = $chromeExe
+    $shortcut.Arguments = '--new-window https://web.whatsapp.com/'
+    $shortcut.IconLocation = "$chromeExe,0"
+    $shortcut.Save()
+}
+
+# Define layout JSON with the desired pins
+$layoutJson = @"
+{
+    ""pinnedList"": [
+        { ""desktopAppLink"": "%APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\System Tools\\File Explorer.lnk" },
+        { ""desktopAppLink"": "%APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Google Chrome.lnk" },
+        { ""desktopAppLink"": "%APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Telegram.lnk" },
+        { ""desktopAppLink"": "%APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\WhatsApp Web.lnk" }
+    ],
+    ""appliedInFullScreenMode"": false
+}
+"@
+
+$tempJson = Join-Path $env:TEMP 'StartPins.json'
+Set-Content -Path $tempJson -Value $layoutJson -Encoding UTF8
+
+try {
+    # Apply layout for the current user and set it as the default for new accounts
+    Import-StartLayout -LayoutPath $tempJson
+    Import-StartLayout -LayoutPath $tempJson -MountPath $env:SystemDrive\
+    Write-Host "✅ Start menu layout applied." -ForegroundColor Green
+} catch {
+    Write-Host "❌ Failed to apply Start menu layout: $_" -ForegroundColor Red
+}
+
+Remove-Item $tempJson -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- add `Configure-StartPins.ps1` to control Start menu pins
- document the new script in README
- remove default Start pins, keeping File Explorer and adding Chrome, Telegram and WhatsApp Web

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840843897088332a967b1e2fbd81fd8