### PR TITLE
Fix missing terminator in Disable-FastStartup

### DIFF
--- a/includes/Disable-FastStartup.ps1
+++ b/includes/Disable-FastStartup.ps1
@@ -1,12 +1,12 @@
 # Disable Fast Startup to ensure proper WoL functionality and clean shutdown
 
-Write-Host "🔧 Disabling Fast Startup..."
+Write-Host "Disabling Fast Startup..."
 
 try {
     reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Power" /v HiberbootEnabled /t REG_DWORD /d 0 /f
-    Write-Host "✅ Fast Startup disabled successfully."
+    Write-Host "Fast Startup disabled successfully."
 } catch {
-    Write-Host "❌ Failed to disable Fast Startup: $_"
+    Write-Host "Failed to disable Fast Startup: $_"
 }
 
-Write-Host "📄 Fast Startup configuration complete."
+Write-Host "Fast Startup configuration complete."


### PR DESCRIPTION
## Summary
- avoid emoji that caused parsing failures in PowerShell

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408cf671fc8332b445ca318ba5a023