### PR TITLE
Fix script parsing error

### DIFF
--- a/includes/Disable-FastStartup.ps1
+++ b/includes/Disable-FastStartup.ps1
@@ -9,4 +9,4 @@ try {
     Write-Host "❌ Failed to disable Fast Startup: $_"
 }
 
-Write-Host "📄 Fast Startup configuration complete."
+Write-Host "Fast Startup configuration complete."

--- a/includes/Enable-WakeOnLan.ps1
+++ b/includes/Enable-WakeOnLan.ps1
@@ -31,4 +31,4 @@ Get-NetAdapter | Where-Object {
     }
 }
 
-Write-Host "📄 Wake on LAN configuration complete."
+Write-Host "Wake on LAN configuration complete."


### PR DESCRIPTION
## Summary
- remove the `📄` emoji from Enable-WakeOnLan.ps1
- remove the `📄` emoji from Disable-FastStartup.ps1

## Testing
- `pwsh -Command "$PSVersionTable.PSVersion.ToString()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408d10c3808332ac311de5b50605e6