### PR TITLE
Fix parse error in Chrome association script

### DIFF
--- a/includes/ZZ-Set-ChromeFileAssociations.ps1
+++ b/includes/ZZ-Set-ChromeFileAssociations.ps1
@@ -2,12 +2,12 @@
 # The alphabetical order of this file (after Install-EssentialApps.ps1)
 # ensures it runs once Chrome is installed.
 
-Write-Host "🔧 Setting Google Chrome defaults..."
+Write-Host "Setting Google Chrome defaults..."
 
 $setUserFtaPath = 'C:\\Scripts\\SetUserFTA.exe'
 
 if (-not (Test-Path $setUserFtaPath)) {
-    Write-Host "⚠️ SetUserFTA not found at $setUserFtaPath. Skipping default browser configuration." -ForegroundColor Yellow
+    Write-Host "SetUserFTA not found at $setUserFtaPath. Skipping default browser configuration." -ForegroundColor Yellow
     return
 }
 
@@ -22,7 +22,7 @@ foreach ($path in $chromePaths) {
 }
 
 if (-not $chromeInstalled) {
-    Write-Host "⚠️ Google Chrome not found. Skipping default browser configuration." -ForegroundColor Yellow
+    Write-Host "Google Chrome not found. Skipping default browser configuration." -ForegroundColor Yellow
     return
 }
 
@@ -41,4 +41,4 @@ foreach ($type in $associations.Keys) {
     & $setUserFtaPath $type $associations[$type] | Out-Null
 }
 
-Write-Host "✅ Google Chrome set as default browser." -ForegroundColor Green
+Write-Host "Google Chrome set as default browser." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- remove emoji characters from `ZZ-Set-ChromeFileAssociations.ps1` to avoid PowerShell parse errors

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408d23d1348332a1069f5bd9273376