### PR TITLE
Fix IE ESC registry path handling

### DIFF
--- a/includes/Disable-IE-Security-Admins.ps1
+++ b/includes/Disable-IE-Security-Admins.ps1
@@ -1,10 +1,26 @@
 # Disable IE Enhanced Security Configuration (ESC)
 function Disable-IEESC {
-    $AdminKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}"
-    $UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
-    Set-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0
-    Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0
-    Stop-Process -Name Explorer
+    $isServer = ((Get-CimInstance Win32_OperatingSystem).ProductType -ne 1)
+    if (-not $isServer) {
+        return
     }
+
+    $AdminKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}" # Admin ESC
+    $UserKey  = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}" # User ESC
+
+    if (Test-Path $AdminKey) {
+        Set-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0
+    }
+
+    if (Test-Path $UserKey) {
+        Set-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0
+    }
+
+    # WARNING: This closes all open File Explorer windows
+    Stop-Process -Name explorer -Force
+
+    # Restart Explorer
+    Start-Process "explorer.exe"
+}
 
 Disable-IEESC


### PR DESCRIPTION
## Summary
- clean up trailing prompt text in Disable-IE-Security-Admins script
- gracefully handle missing registry paths when disabling Internet Explorer ESC
- add server check and restart explorer when IE ESC is disabled

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408d00db3c8332b8dd1e87a4652c7b