### PR TITLE
Fix property creation in WiFi Sense script

### DIFF
--- a/includes/Disable-WiFi-HotSpot-Autoconnect.ps1
+++ b/includes/Disable-WiFi-HotSpot-Autoconnect.ps1
@@ -1,5 +1,13 @@
-# WiFi Sense: HotSpot Sharing: Disable
-Set-ItemProperty -Path HKLM:\Software\Microsoft\PolicyManager\default\WiFi\AllowWiFiHotSpotReporting -Name value -Type DWord -Value 0
+# Disable WiFi Sense: HotSpot Sharing
+$hotSpotReportingPath = "HKLM:\Software\Microsoft\PolicyManager\default\WiFi\AllowWiFiHotSpotReporting"
+if (!(Test-Path $hotSpotReportingPath)) {
+    New-Item -Path $hotSpotReportingPath -Force | Out-Null
+}
+New-ItemProperty -Path $hotSpotReportingPath -Name "value" -PropertyType DWord -Value 0 -Force
 
-# WiFi Sense: Shared HotSpot Auto-Connect: Disable
-Set-ItemProperty -Path HKLM:\Software\Microsoft\PolicyManager\default\WiFi\AllowAutoConnectToWiFiSenseHotspots -Name value -Type DWord -Value 0
+# Disable WiFi Sense: Shared HotSpot Auto-Connect
+$autoConnectPath = "HKLM:\Software\Microsoft\PolicyManager\default\WiFi\AllowAutoConnectToWiFiSenseHotspots"
+if (!(Test-Path $autoConnectPath)) {
+    New-Item -Path $autoConnectPath -Force | Out-Null
+}
+New-ItemProperty -Path $autoConnectPath -Name "value" -PropertyType DWord -Value 0 -Force


### PR DESCRIPTION
## Summary
- create registry values using `New-ItemProperty` in `Disable-WiFi-HotSpot-Autoconnect.ps1`
- update comments in the script

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408d09996c83328062487e38e367c2