### PR TITLE
Fix BitLocker recovery key path

### DIFF
--- a/includes/ZZ-Enable-BitLocker.ps1
+++ b/includes/ZZ-Enable-BitLocker.ps1
@@ -1,25 +1,29 @@
 # Check if BitLocker is enabled
-$bitlockerStatus = Get-BitLockerVolume -MountPoint "C:"
+$bitlockerStatus = Get-BitLockerVolume -MountPoint 'C:'
 
 if ($bitlockerStatus.ProtectionStatus -eq 'Off') {
-    Write-Host "[INFO] Enabling BitLocker on C: drive..."
+    Write-Host '[INFO] Enabling BitLocker on C: drive...'
 
     # Enable BitLocker using TPM and create a recovery password
-    Enable-BitLocker -MountPoint "C:" -EncryptionMethod XtsAes256 -TpmProtector -RecoveryPasswordProtector -UsedSpaceOnly
+    Enable-BitLocker -MountPoint 'C:' -EncryptionMethod XtsAes256 -TpmProtector -RecoveryPasswordProtector -UsedSpaceOnly
 
     # Retrieve the generated recovery password
-    $recoveryPassword = (Get-BitLockerVolume -MountPoint "C:").KeyProtector |
+    $recoveryPassword = (Get-BitLockerVolume -MountPoint 'C:').KeyProtector |
         Where-Object { $_.KeyProtectorType -eq 'RecoveryPassword' } |
         Select-Object -ExpandProperty RecoveryPassword
 
-    # Save recovery info with computer details
-    $keyPath = "C:\BitLockerRecoveryKey.txt"
+    # Save recovery info inside the user's Documents folder with the
+    # computer name appended to the file name
+    $documents = Join-Path $env:USERPROFILE 'Documents'
+    $keyFile  = "BitLockerRecoveryKey-$env:COMPUTERNAME.txt"
+    $keyPath  = Join-Path $documents $keyFile
+
     $info = @(
         "ComputerName: $env:COMPUTERNAME",
         "Date: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')",
         "RecoveryPassword: $recoveryPassword"
     )
-    $info | Out-File -FilePath $keyPath -Encoding UTF8
+    $info | Set-Content -Path $keyPath -Encoding UTF8
 
     Write-Host "[OK] BitLocker enabled. Recovery info saved to $keyPath"
 } else {


### PR DESCRIPTION
## Summary
- store BitLocker recovery info in the user's Documents folder
- include the computer name in the recovery file name

## Testing
- `pwsh -Version` *(fails: command not found)*
- `powershell -Version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684091eefd0c8332ac715ebd3f5fc171