### PR TITLE
Fix SetUserFTA path in Set-OfficeSuiteDefaults

### DIFF
--- a/includes/Set-OfficeSuiteDefaults.ps1
+++ b/includes/Set-OfficeSuiteDefaults.ps1
@@ -1,8 +1,12 @@
 # Prompt for default office suite and configure file associations
 
 $setUserFtaPath = Join-Path $env:TEMP 'SetUserFTA.exe'
+# Fall back to the location used by Install-EssentialApps.ps1
 if (-not (Test-Path $setUserFtaPath)) {
-    Write-Host "SetUserFTA not found at $setUserFtaPath" -ForegroundColor Yellow
+    $setUserFtaPath = 'C:\Scripts\SetUserFTA.exe'
+}
+if (-not (Test-Path $setUserFtaPath)) {
+    Write-Host "SetUserFTA not found. Skipping office suite defaults." -ForegroundColor Yellow
     return
 }
 


### PR DESCRIPTION
## Summary
- handle missing tool in `Set-OfficeSuiteDefaults.ps1` by checking the path used by Install-EssentialApps

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840920ca50c8332bab176a30804d3fd