### PR TITLE
Fix PowerShell winget id

### DIFF
--- a/includes/Install-EssentialApps.ps1
+++ b/includes/Install-EssentialApps.ps1
@@ -83,7 +83,9 @@ $apps = @(
     @{ Name = "LibreOffice"; Id = "TheDocumentFoundation.LibreOffice" },
 
     # Developer Tools (for scripting, coding, and terminal access)
-    @{ Name = "PowerShell 7"; Id = "Microsoft.Powershell" },
+    # Use the official PowerShell package identifier. The old value
+    # "Microsoft.Powershell" fails to resolve with winget.
+    @{ Name = "PowerShell 7"; Id = "Microsoft.PowerShell" },
     @{ Name = "Python"; Id = "Python.Python.3" },
     @{ Name = "Windows Terminal"; Id = "Microsoft.WindowsTerminal" }
 )


### PR DESCRIPTION
## Summary
- fix the package id for PowerShell in `Install-EssentialApps.ps1`

## Testing
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684098afa19c8332a2f18d2e582a0cd0