### PR TITLE
Fix Import-StartLayout MountPath quoting

### DIFF
--- a/includes/Configure-StartPins.ps1
+++ b/includes/Configure-StartPins.ps1
@@ -61,7 +61,7 @@ Set-Content -Path $tempJson -Value $layoutJson -Encoding UTF8
 try {
     # Apply layout for the current user and set it as the default for new accounts
     Import-StartLayout -LayoutPath $tempJson
-    Import-StartLayout -LayoutPath $tempJson -MountPath $env:SystemDrive\
+    Import-StartLayout -LayoutPath $tempJson -MountPath "$env:SystemDrive\"
     Write-Host "[OK] Start menu layout applied." -ForegroundColor Green
 } catch {
     Write-Host "[ERROR] Failed to apply Start menu layout: $_" -ForegroundColor Red


### PR DESCRIPTION
## Summary
- quote the mount path so the Start menu script no longer prompts for it

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409a7ea6588332bbf3f1e440ae2adf