### PR TITLE
Fix Start menu pin configuration

### DIFF
--- a/includes/Configure-StartPins.ps1
+++ b/includes/Configure-StartPins.ps1
@@ -59,8 +59,9 @@ $tempJson = Join-Path $env:TEMP 'StartPins.json'
 Set-Content -Path $tempJson -Value $layoutJson -Encoding UTF8
 
 try {
-    # Apply layout for the current user and set it as the default for new accounts
-    Import-StartLayout -LayoutPath $tempJson
+    # Apply layout for the running system and also set it as the default
+    # for any new accounts. Using -MountPath avoids interactive prompts on
+    # recent Windows builds where the parameter is required.
     Import-StartLayout -LayoutPath $tempJson -MountPath "$env:SystemDrive\"
     Write-Host "[OK] Start menu layout applied." -ForegroundColor Green
 } catch {


### PR DESCRIPTION
## Summary
- fix Import-StartLayout usage in Configure-StartPins

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409dbed6a48332acdd52ec59ac86e5