### PR TITLE
Add model & serial info to wallpaper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The project started as a fork of [filipnet/customize-windows-client](https://git
 
    The script asks whether to create a system restore point and backup the registry, then asks for confirmation before customizing Windows and again before rebooting. Press `y` and **Enter** when prompted.
 
-Each script in `includes` performs a single customization step—such as disabling Cortana, blocking Microsoft account sign-in and Windows Hello for Business, configuring Windows Update, or installing useful tools. `Configure-StartPins.ps1` resets pinned items to File Explorer, Google Chrome, Telegram and WhatsApp Web. `Set-WallpaperWithStats.ps1` can set a wallpaper and overlay basic system information.
+Each script in `includes` performs a single customization step—such as disabling Cortana, blocking Microsoft account sign-in and Windows Hello for Business, configuring Windows Update, or installing useful tools. `Configure-StartPins.ps1` resets pinned items to File Explorer, Google Chrome, Telegram and WhatsApp Web. `Set-WallpaperWithStats.ps1` sets the wallpaper and overlays system information—computer name, model, serial number and Windows version—in the bottom-right corner of the screen.
 
 ## Troubleshooting
 

--- a/includes/Set-WallpaperWithStats.ps1
+++ b/includes/Set-WallpaperWithStats.ps1
@@ -17,6 +17,8 @@ if (-not (Test-Path $wallpaperImage)) {
 $computerName  = $env:COMPUTERNAME
 $workgroup     = (Get-CimInstance Win32_ComputerSystem).Workgroup
 $windowsVer    = (Get-CimInstance Win32_OperatingSystem).Caption
+$pcModel       = (Get-CimInstance Win32_ComputerSystem).Model
+$serialNumber  = (Get-CimInstance Win32_BIOS).SerialNumber
 
 # Load image and overlay text
 Add-Type -AssemblyName System.Drawing
@@ -25,8 +27,11 @@ $graphics  = [System.Drawing.Graphics]::FromImage($image)
 $font      = New-Object System.Drawing.Font('Arial',14)
 $brush     = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::Yellow)
 
-$infoText  = "PC: $computerName`nWorkgroup: $workgroup`nWindows: $windowsVer"
-$graphics.DrawString($infoText,$font,$brush,10,10)
+$infoText  = "PC: $computerName`nModel: $pcModel`nSerial: $serialNumber`nWorkgroup: $workgroup`nWindows: $windowsVer"
+$size      = $graphics.MeasureString($infoText,$font)
+$x         = $image.Width  - $size.Width  - 10
+$y         = $image.Height - $size.Height - 10
+$graphics.DrawString($infoText,$font,$brush,$x,$y)
 
 # Save the temporary bitmap (wallpaper must be BMP format)
 $tempBmp   = Join-Path $env:TEMP 'wallpaper-with-stats.bmp'

--- a/wallpaper/README.md
+++ b/wallpaper/README.md
@@ -1,2 +1,3 @@
 Place your wallpaper image in this directory and update the filename in `Set-WallpaperWithStats.ps1`.
+The script overlays the computer name, model, serial number and Windows version in the bottom-right corner of the wallpaper.
 


### PR DESCRIPTION
## Summary
- show system model and serial numbers on wallpaper
- place info overlay in bottom-right corner
- document new wallpaper info behavior

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a6719c248332902ff9c2d1dafa06