### PR TITLE
Fix wallpaper overlay getting obscured

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The project started as a fork of [filipnet/customize-windows-client](https://git
 
    The script asks whether to create a system restore point and backup the registry, then asks for confirmation before customizing Windows and again before rebooting. Press `y` and **Enter** when prompted.
 
-Each script in `includes` performs a single customization step—such as disabling Cortana, blocking Microsoft account sign-in and Windows Hello for Business, configuring Windows Update, or installing useful tools. `Configure-StartPins.ps1` resets pinned items to File Explorer, Google Chrome, Telegram and WhatsApp Web. `Set-WallpaperWithStats.ps1` sets the wallpaper and overlays system information—computer name, model, serial number and Windows version—in the bottom-right corner of the screen.
+Each script in `includes` performs a single customization step—such as disabling Cortana, blocking Microsoft account sign-in and Windows Hello for Business, configuring Windows Update, or installing useful tools. `Configure-StartPins.ps1` resets pinned items to File Explorer, Google Chrome, Telegram and WhatsApp Web. `Set-WallpaperWithStats.ps1` sets the wallpaper and overlays system information—computer name, model, serial number and Windows version—in the bottom-right corner of the screen. If the text is hidden behind the taskbar, adjust the `$bottomMargin` variable in that script.
 
 ## Troubleshooting
 

--- a/includes/Set-WallpaperWithStats.ps1
+++ b/includes/Set-WallpaperWithStats.ps1
@@ -27,10 +27,13 @@ $graphics  = [System.Drawing.Graphics]::FromImage($image)
 $font      = New-Object System.Drawing.Font('Arial',14)
 $brush     = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::Yellow)
 
-$infoText  = "PC: $computerName`nModel: $pcModel`nSerial: $serialNumber`nWorkgroup: $workgroup`nWindows: $windowsVer"
-$size      = $graphics.MeasureString($infoText,$font)
-$x         = $image.Width  - $size.Width  - 10
-$y         = $image.Height - $size.Height - 10
+$infoText      = "PC: $computerName`nModel: $pcModel`nSerial: $serialNumber`nWorkgroup: $workgroup`nWindows: $windowsVer"
+$size          = $graphics.MeasureString($infoText,$font)
+
+# leave extra space so the taskbar doesn't cover the overlay text
+$bottomMargin  = 60
+$x             = $image.Width  - $size.Width  - 10
+$y             = $image.Height - $size.Height - $bottomMargin
 $graphics.DrawString($infoText,$font,$brush,$x,$y)
 
 # Save the temporary bitmap (wallpaper must be BMP format)


### PR DESCRIPTION
## Summary
- ensure wallpaper overlay text isn't hidden by adding a bottom margin
- document how to adjust the margin if the text is blocked

## Testing
- `powershell` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ad5b75d883329020a60054d2ce31