### PR TITLE
Fix path not found COMException during app removal

### DIFF
--- a/includes/Uninstall-Default-Software-Packages.ps1
+++ b/includes/Uninstall-Default-Software-Packages.ps1
@@ -17,7 +17,14 @@ function Uninstall-PackageIfPresent {
 
     $prov = Get-AppxProvisionedPackage -Online | Where-Object DisplayName -like $Identifier
     if ($null -ne $prov) {
-        $prov | Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue
+        try {
+            $prov | Remove-AppxProvisionedPackage -Online -ErrorAction Stop
+        }
+        catch [System.Runtime.InteropServices.COMException] {
+            if ($_.Exception.HResult -ne -2147024893) {
+                throw
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ignore COMException for missing provisioned Appx packages

## Testing
- `pwsh` *(fails: command not found)*
- `powershell` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c61317ac83328d7624e8bf785c7d