### PR TITLE
Standardize SetUserFTA path checks

### DIFF
--- a/includes/Set-OfficeSuiteDefaults.ps1
+++ b/includes/Set-OfficeSuiteDefaults.ps1
@@ -6,7 +6,7 @@ if (-not (Test-Path $setUserFtaPath)) {
     $setUserFtaPath = 'C:\Scripts\SetUserFTA.exe'
 }
 if (-not (Test-Path $setUserFtaPath)) {
-    Write-Host "SetUserFTA not found. Skipping office suite defaults." -ForegroundColor Yellow
+    Write-Warning "SetUserFTA.exe not found. Ensure Install-EssentialApps.ps1 was executed."
     return
 }
 

--- a/includes/ZZ-Set-ChromeFileAssociations.ps1
+++ b/includes/ZZ-Set-ChromeFileAssociations.ps1
@@ -4,10 +4,12 @@
 
 Write-Host "Setting Google Chrome defaults..."
 
-$setUserFtaPath = 'C:\\Scripts\\SetUserFTA.exe'
-
+$setUserFtaPath = Join-Path $env:TEMP 'SetUserFTA.exe'
 if (-not (Test-Path $setUserFtaPath)) {
-    Write-Host "SetUserFTA not found at $setUserFtaPath. Skipping default browser configuration." -ForegroundColor Yellow
+    $setUserFtaPath = 'C:\\Scripts\\SetUserFTA.exe'
+}
+if (-not (Test-Path $setUserFtaPath)) {
+    Write-Warning "SetUserFTA.exe not found. Ensure Install-EssentialApps.ps1 was executed."
     return
 }
 


### PR DESCRIPTION
## Summary
- standardize the fallback logic for SetUserFTA.exe
- warn if SetUserFTA.exe is missing

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c61e8f148332839bd168c55bcb25