### PR TITLE
Add standard user creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ The project started as a fork of [filipnet/customize-windows-client](https://git
    reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v BlockUserFromCreatingAccounts /t REG_DWORD /d 0 /f
    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\UserProfileEngagement" /v ScoobeSystemSettingEnabled /t REG_DWORD /d 1 /f
    ```
-7. **Run the script from the same console** so you can respond to prompts:
+7. Run `Create-Standard-User.ps1` to create a local account without administrator rights. You
+   will be prompted for a user name and to confirm the password.
+8. **Run the script from the same console** so you can respond to prompts:
 
    ```powershell
    .\customize-windows-client.ps1

--- a/includes/Create-Standard-User.ps1
+++ b/includes/Create-Standard-User.ps1
@@ -1,0 +1,15 @@
+## Create standard user account
+
+$username = Read-Host 'Enter a user name for the standard account'
+do {
+    $pw1 = Read-Host 'Enter password'
+    $pw2 = Read-Host 'Confirm password'
+    if ($pw1 -ne $pw2) {
+        Write-Warning 'Passwords do not match. Please try again.'
+    }
+} until ($pw1 -eq $pw2)
+
+net user $username $pw1 /add
+net localgroup Users $username /add
+
+Write-Host "Created standard user account '$username'."


### PR DESCRIPTION
## Summary
- add `Create-Standard-User.ps1` for creating local non-admin accounts
- document the new script in README

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416a646530833288cd376cb08899d9