### PR TITLE
Secure password prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The project started as a fork of [filipnet/customize-windows-client](https://git
    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\UserProfileEngagement" /v ScoobeSystemSettingEnabled /t REG_DWORD /d 1 /f
    ```
 7. Run `Create-Standard-User.ps1` to create a local account without administrator rights. You
-   will be prompted for a user name and to confirm the password.
+   will be prompted for a user name and to enter the password twice. The password input
+   is hidden and therefore not written to the transcript log.
 8. **Run the script from the same console** so you can respond to prompts:
 
    ```powershell

--- a/includes/Create-Standard-User.ps1
+++ b/includes/Create-Standard-User.ps1
@@ -1,15 +1,27 @@
 ## Create standard user account
 
+function ConvertTo-PlainText {
+    param([System.Security.SecureString]$SecureString)
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+    try {
+        [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+    }
+    finally {
+        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+    }
+}
+
 $username = Read-Host 'Enter a user name for the standard account'
 do {
-    $pw1 = Read-Host 'Enter password'
-    $pw2 = Read-Host 'Confirm password'
-    if ($pw1 -ne $pw2) {
+    $pw1 = Read-Host 'Enter password' -AsSecureString
+    $pw2 = Read-Host 'Confirm password' -AsSecureString
+    if ((ConvertTo-PlainText $pw1) -ne (ConvertTo-PlainText $pw2)) {
         Write-Warning 'Passwords do not match. Please try again.'
     }
-} until ($pw1 -eq $pw2)
+} until ((ConvertTo-PlainText $pw1) -eq (ConvertTo-PlainText $pw2))
 
-net user $username $pw1 /add
+$plainPassword = ConvertTo-PlainText $pw1
+net user $username $plainPassword /add
 net localgroup Users $username /add
 
 Write-Host "Created standard user account '$username'."

--- a/includes/ZZ-Disable-MicrosoftAccount.ps1
+++ b/includes/ZZ-Disable-MicrosoftAccount.ps1
@@ -33,14 +33,26 @@ if ($hasMicrosoftAccount) {
         $create = Read-Host 'Would you like to create a local account now? [y/N]'
         if ($create -eq 'y') {
             $username = Read-Host 'Enter a user name for the new account'
+            function ConvertTo-PlainText {
+                param([System.Security.SecureString]$SecureString)
+                $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
+                try {
+                    [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+                }
+                finally {
+                    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+                }
+            }
+
             do {
-                $pw1 = Read-Host 'Enter password'
-                $pw2 = Read-Host 'Confirm password'
-                if ($pw1 -ne $pw2) {
+                $pw1 = Read-Host 'Enter password' -AsSecureString
+                $pw2 = Read-Host 'Confirm password' -AsSecureString
+                if ((ConvertTo-PlainText $pw1) -ne (ConvertTo-PlainText $pw2)) {
                     Write-Warning 'Passwords do not match. Please try again.'
                 }
-            } until ($pw1 -eq $pw2)
-            net user $username $pw1 /add
+            } until ((ConvertTo-PlainText $pw1) -eq (ConvertTo-PlainText $pw2))
+            $plainPassword = ConvertTo-PlainText $pw1
+            net user $username $plainPassword /add
             net localgroup Administrators $username /add
             Write-Host "Created local administrator account '$username'."
             $hasLocalAccount = $true


### PR DESCRIPTION
## Summary
- hide password input when creating a user
- hide password input when creating a local account in the Microsoft account module
- clarify password prompt behavior in the README

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c59ec3cc8332a08894651889feec