### PR TITLE
Add TPM check before enabling BitLocker

### DIFF
--- a/includes/ZZ-Enable-BitLocker.ps1
+++ b/includes/ZZ-Enable-BitLocker.ps1
@@ -1,3 +1,16 @@
+$tpm = $null
+try {
+    $tpm = Get-Tpm
+} catch {
+    Write-Warning "Failed to query TPM status: $_"
+    return
+}
+
+if (-not $tpm.TpmPresent -or -not $tpm.TpmReady) {
+    Write-Warning "TPM not present or not ready. Skipping BitLocker configuration."
+    return
+}
+
 # Check if BitLocker is enabled
 $bitlockerStatus = Get-BitLockerVolume -MountPoint 'C:'
 


### PR DESCRIPTION
## Summary
- check the TPM status before enabling BitLocker
- warn and exit when the TPM isn't available

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e946a5c483329e959d2a5367eb9d