### PR TITLE
Rename shared functions and add account helpers

### DIFF
--- a/apply-user-customizations.ps1
+++ b/apply-user-customizations.ps1
@@ -12,8 +12,8 @@ analysis. Scripts requiring administrator rights are excluded.
 $ScriptRoot   = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $IncludesPath = Join-Path $ScriptRoot 'includes'
 
-# Load shared registry helper functions if present
-$regPath = Join-Path $IncludesPath 'Registry-Functions.ps1'
+# Load shared helper functions if present
+$regPath = Join-Path $IncludesPath 'Shared-Functions.ps1'
 if (Test-Path $regPath) {
     . $regPath
 }

--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -36,8 +36,8 @@ $FOREGROUNDCOLOR = "Yellow"
 # folder relative to its own location.
 $ScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $IncludesPath = Join-Path $ScriptRoot 'includes'
-# Load registry helper functions for all scripts
-. (Join-Path $IncludesPath 'Registry-Functions.ps1')
+# Load shared helper functions for all scripts
+. (Join-Path $IncludesPath 'Shared-Functions.ps1')
 $templateFunctionsPath = Join-Path $IncludesPath 'Profile-Template-Functions.ps1'
 if (Test-Path $templateFunctionsPath) {
     . $templateFunctionsPath

--- a/includes/ZZ-Disable-MicrosoftAccount.ps1
+++ b/includes/ZZ-Disable-MicrosoftAccount.ps1
@@ -33,28 +33,15 @@ if ($hasMicrosoftAccount) {
         $create = Read-Host 'Would you like to create a local account now? [y/N]'
         if ($create -eq 'y') {
             $username = Read-Host 'Enter a user name for the new account'
-            function ConvertTo-PlainText {
-                param([System.Security.SecureString]$SecureString)
-                $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
-                try {
-                    [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
-                }
-                finally {
-                    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-                }
-            }
-
             do {
                 $pw1 = Read-Host 'Enter password' -AsSecureString
                 $pw2 = Read-Host 'Confirm password' -AsSecureString
-                if ((ConvertTo-PlainText $pw1) -ne (ConvertTo-PlainText $pw2)) {
+                if ([System.Net.NetworkCredential]::new('', $pw1).Password -ne [System.Net.NetworkCredential]::new('', $pw2).Password) {
                     Write-Warning 'Passwords do not match. Please try again.'
                 }
-            } until ((ConvertTo-PlainText $pw1) -eq (ConvertTo-PlainText $pw2))
-            $plainPassword = ConvertTo-PlainText $pw1
-            net user $username $plainPassword /add
-            net localgroup Administrators $username /add
-            Write-Host "Created local administrator account '$username'."
+            } until ([System.Net.NetworkCredential]::new('', $pw1).Password -eq [System.Net.NetworkCredential]::new('', $pw2).Password)
+
+            New-LocalUserAccount -Username $username -Password $pw1 -Groups @('Administrators')
             $hasLocalAccount = $true
         }
     }

--- a/includes/ZZZ-Create-Standard-User.ps1
+++ b/includes/ZZZ-Create-Standard-User.ps1
@@ -1,27 +1,20 @@
 ## Create standard user account
 
-function ConvertTo-PlainText {
-    param([System.Security.SecureString]$SecureString)
-    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
-    try {
-        [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
-    }
-    finally {
-        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-    }
+$confirm = Read-Host 'Create a new standard user account? [y/N]'
+if ($confirm -ne 'y') {
+    Write-Host 'User creation cancelled.'
+    return
 }
 
 $username = Read-Host 'Enter a user name for the standard account'
 do {
     $pw1 = Read-Host 'Enter password' -AsSecureString
     $pw2 = Read-Host 'Confirm password' -AsSecureString
-    if ((ConvertTo-PlainText $pw1) -ne (ConvertTo-PlainText $pw2)) {
+    if ([System.Net.NetworkCredential]::new('', $pw1).Password -ne [System.Net.NetworkCredential]::new('', $pw2).Password) {
         Write-Warning 'Passwords do not match. Please try again.'
     }
-} until ((ConvertTo-PlainText $pw1) -eq (ConvertTo-PlainText $pw2))
+} until ([System.Net.NetworkCredential]::new('', $pw1).Password -eq [System.Net.NetworkCredential]::new('', $pw2).Password)
 
-$plainPassword = ConvertTo-PlainText $pw1
-net user $username $plainPassword /add
-net localgroup Users $username /add
+New-LocalUserAccount -Username $username -Password $pw1 -Groups @('Users')
 
 Write-Host "Created standard user account '$username'."


### PR DESCRIPTION
## Summary
- rename `Registry-Functions.ps1` -> `Shared-Functions.ps1`
- update scripts to load `Shared-Functions.ps1`
- add account management utilities in the shared functions file
- use the new helpers in account-related scripts

## Testing
- `powershell` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ed2ee9208332b99df6ac3b50f904