### PR TITLE
Adjust desktop shortcut install behavior

### DIFF
--- a/includes/Install-EssentialApps.ps1
+++ b/includes/Install-EssentialApps.ps1
@@ -86,12 +86,20 @@ $apps = @(
     @{ Name = "Windows Terminal"; Id = "Microsoft.WindowsTerminal" }
 )
 
+# Apps that should not have shortcuts copied to the public desktop
+$skipShortcutApps = @('PowerShell 7','Python')
+
 foreach ($app in $apps) {
     Write-Host "[INFO] Installing $($app.Name)..." -ForegroundColor Cyan
     try {
         winget install --id=$($app.Id) --accept-source-agreements --accept-package-agreements -e -h --disable-interactivity --scope machine
         Write-Host "[OK] Installed $($app.Name)" -ForegroundColor Green
-        Add-DesktopShortcut -AppName $app.Name
+
+        if ($skipShortcutApps -notcontains $app.Name) {
+            Add-DesktopShortcut -AppName $app.Name
+        } else {
+            Write-Host "[INFO] Skipping desktop shortcut for $($app.Name)" -ForegroundColor Gray
+        }
     } catch {
         Write-Host "[ERROR] Failed to install $($app.Name): $_" -ForegroundColor Red
     }

--- a/includes/Install-EssentialApps.ps1
+++ b/includes/Install-EssentialApps.ps1
@@ -87,7 +87,16 @@ $apps = @(
 )
 
 # Apps that should not have shortcuts copied to the public desktop
-$skipShortcutApps = @('PowerShell 7','Python')
+$skipShortcutApps = @(
+    '.NET Desktop Runtime 6',
+    '.NET Desktop Runtime 7',
+    '.NET Desktop Runtime 8',
+    'Microsoft Visual C++ 2015-2022 Redistributable (x64)',
+    'Microsoft Visual C++ 2015-2022 Redistributable (x86)',
+    'PowerShell 7',
+    'Python',
+    'Windows Terminal'
+)
 
 foreach ($app in $apps) {
     Write-Host "[INFO] Installing $($app.Name)..." -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- skip adding public desktop shortcuts for Python and PowerShell

## Testing
- `powershell -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f6d8c4cc8332bf22f977952f45c5