### PR TITLE
Fix Telegram shortcut detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Bypa
 
 ### ⚙️ System Optimisation
 - **Installs essential applications** via Windows Package Manager (winget)
+- **Adds desktop shortcuts** for installed apps by scanning all Start Menu folders
 - **Configures Windows Update** with intelligent scheduling and deferral
 - **Sets up automatic app updates** via scheduled task
 - **Optimises power management** settings

--- a/includes/Install-EssentialApps.ps1
+++ b/includes/Install-EssentialApps.ps1
@@ -22,12 +22,21 @@ function Download-File {
 function Add-DesktopShortcut {
     param([string]$AppName)
 
-    $startDir   = [Environment]::GetFolderPath('CommonPrograms')
     $desktopDir = [Environment]::GetFolderPath('CommonDesktopDirectory')
+    $startDirs  = @(
+        [Environment]::GetFolderPath('CommonPrograms'),
+        [Environment]::GetFolderPath('Programs')
+    )
 
-    $shortcut = Get-ChildItem -Path $startDir -Include *.lnk,*.url,*.appref-ms -Recurse |
-                Where-Object { $_.BaseName -like "*$AppName*" } |
-                Select-Object -First 1
+    $shortcut = $null
+    foreach ($dir in $startDirs) {
+        if (Test-Path $dir) {
+            $shortcut = Get-ChildItem -Path $dir -Include *.lnk,*.url,*.appref-ms -Recurse |
+                        Where-Object { $_.BaseName -like "*$AppName*" } |
+                        Select-Object -First 1
+            if ($null -ne $shortcut) { break }
+        }
+    }
 
     if ($null -ne $shortcut) {
         $destination = Join-Path $desktopDir $shortcut.Name


### PR DESCRIPTION
## Summary
- improve `Add-DesktopShortcut` to search all Start Menu folders
- document that the toolkit now adds desktop shortcuts for installed apps

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f719744083329ab6680958d6bdcc