### PR TITLE
Fix default profile hive mount

### DIFF
--- a/includes/Profile-Template-Functions.ps1
+++ b/includes/Profile-Template-Functions.ps1
@@ -13,7 +13,8 @@ function Mount-DefaultUserHive {
             throw "Default user profile not found: $defaultProfilePath"
         }
 
-        $result = & reg.exe load "HKU\\DEFAULT_TEMPLATE" "C:\\Users\\Default\\NTUSER.DAT" 2>&1
+        # Use variables for mount point and profile path to avoid quoting issues
+        $result = & reg.exe load $mountPoint $defaultProfilePath 2>&1
         if ($LASTEXITCODE -ne 0) {
             if (Get-ChildItem Registry::HKEY_USERS | Where-Object { $_.PSChildName -eq 'DEFAULT_TEMPLATE' }) {
                 Write-Host "[TEMPLATE] Default user hive already mounted" -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- ensure `reg.exe` receives mount parameters without hardcoded quoting

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684701e9cb0c83329b009ee61806cd1a