### PR TITLE
Fix scheduled task trigger for PowerShell 5.1

### DIFF
--- a/includes/Schedule-Daily-Shutdown.ps1
+++ b/includes/Schedule-Daily-Shutdown.ps1
@@ -27,9 +27,12 @@ Set-Content -Path $scriptPath -Value $scriptContent -Encoding UTF8 -Force
 Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
 
 # Create trigger: start at 9:00 PM and repeat every 15 minutes for 6 hours
-$trigger = New-ScheduledTaskTrigger -Daily -At "9:00 PM"
-$trigger.Repetition.Interval  = (New-TimeSpan -Minutes 15)
-$trigger.Repetition.Duration  = (New-TimeSpan -Hours 6)
+# Older PowerShell versions (e.g. 5.1) don't expose the Repetition property
+# on the trigger object, so the interval and duration must be set when the
+# trigger is created.
+$trigger = New-ScheduledTaskTrigger -Daily -At "9:00 PM" `
+    -RepetitionInterval (New-TimeSpan -Minutes 15) `
+    -RepetitionDuration (New-TimeSpan -Hours 6)
 
 # Define action
 $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`""


### PR DESCRIPTION
## Summary
- ensure repetition options work on PowerShell 5.1

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684701fbf72483328855016e09d3c932