### PR TITLE
Fix default user hive mount

### DIFF
--- a/includes/Profile-Template-Functions.ps1
+++ b/includes/Profile-Template-Functions.ps1
@@ -7,14 +7,14 @@ function Mount-DefaultUserHive {
     param()
     try {
         $defaultProfilePath = "C:\\Users\\Default\\NTUSER.DAT"
-        $mountPoint = "HKU\\DEFAULT_TEMPLATE"
+        $mountPoint = "HKEY_USERS\\DEFAULT_TEMPLATE"
 
         if (!(Test-Path $defaultProfilePath)) {
             throw "Default user profile not found: $defaultProfilePath"
         }
 
         # Use variables for mount point and profile path to avoid quoting issues
-        $result = & reg.exe load $mountPoint $defaultProfilePath 2>&1
+        $result = & reg.exe load "$mountPoint" "$defaultProfilePath" 2>&1
         if ($LASTEXITCODE -ne 0) {
             if (Get-ChildItem Registry::HKEY_USERS | Where-Object { $_.PSChildName -eq 'DEFAULT_TEMPLATE' }) {
                 Write-Host "[TEMPLATE] Default user hive already mounted" -ForegroundColor Yellow
@@ -36,9 +36,9 @@ function Dismount-DefaultUserHive {
     [CmdletBinding()]
     param()
     try {
-        $mountPoint = "HKU\\DEFAULT_TEMPLATE"
+        $mountPoint = "HKEY_USERS\\DEFAULT_TEMPLATE"
         if (Get-ChildItem Registry::HKEY_USERS | Where-Object { $_.Name -like '*DEFAULT_TEMPLATE' }) {
-            $result = & reg.exe unload "HKU\\DEFAULT_TEMPLATE" 2>&1
+            $result = & reg.exe unload "$mountPoint" 2>&1
             if ($LASTEXITCODE -ne 0) {
                 throw "Failed to dismount default user hive: $result"
             }


### PR DESCRIPTION
## Summary
- fix quoting and key path when loading the default user registry hive

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684703cdb3cc833291193dbcab2a2f8a