### PR TITLE
Fix registry value copy and update unzip guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,11 @@ powershell -ExecutionPolicy Bypass .\customize-windows-client.ps1
 - Ensure `SetUserFTA.exe` downloaded successfully to `C:\Scripts\`
 - Verify target applications installed correctly
 - Run file association scripts after application installation
+- **Parsing Errors After Manual Extraction:**
+  - Some third-party unzip tools can corrupt PowerShell files
+  - Re-download using the provided `download-repo.ps1` script or `Expand-Archive`
+  - Confirm `Profile-Template-Functions.ps1` contains around 430 lines
+  - If issues persist, clone the repo using `git clone` to avoid line-ending corruption
 
 ### Recovery Procedures
 

--- a/includes/Profile-Template-Functions.ps1
+++ b/includes/Profile-Template-Functions.ps1
@@ -255,7 +255,11 @@ function Copy-SpecificRegistryValues {
                         $valueData = $value.$valueName
                         $valueType = (Get-Item -Path $Section.Source).GetValueKind($valueName)
 
-                        Set-ItemProperty -Path $Section.Destination -Name $valueName -Value $valueData -Type $valueType -Force
+                        if (Get-ItemProperty -Path $Section.Destination -Name $valueName -ErrorAction SilentlyContinue) {
+                            Set-ItemProperty -Path $Section.Destination -Name $valueName -Value $valueData -Force
+                        } else {
+                            New-ItemProperty -Path $Section.Destination -Name $valueName -Value $valueData -PropertyType $valueType -Force | Out-Null
+                        }
                         Write-Host "    Copied value: $valueName" -ForegroundColor Gray
                     }
                 }


### PR DESCRIPTION
## Summary
- fix Set-ItemProperty usage by creating values when missing
- add note to clone repo if unzip corruption persists

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471a648cf48332ba7f1800785c11a4