### PR TITLE
Fix Export-ModuleMember error

### DIFF
--- a/includes/Profile-Template-Functions.ps1
+++ b/includes/Profile-Template-Functions.ps1
@@ -10,4 +10,3 @@ function Invoke-ProfileTemplate {
     return $true
 }
 
-Export-ModuleMember -Function Invoke-ProfileTemplate


### PR DESCRIPTION
## Summary
- remove `Export-ModuleMember` from `Profile-Template-Functions.ps1` because the file is dot-sourced and not a module

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684726911c788332aa70e932b2312b14