### PR TITLE
Fix missing task handling

### DIFF
--- a/includes/Strengthen-Privacy.ps1
+++ b/includes/Strengthen-Privacy.ps1
@@ -17,10 +17,19 @@ $tasksToDisable = @(
 
 foreach ($task in $tasksToDisable) {
     try {
-        Disable-ScheduledTask -TaskName $task -ErrorAction Stop | Out-Null
-        Write-Host "[TASK] Disabled: $task" -ForegroundColor Green
+        $taskName = Split-Path $task -Leaf
+        $taskPath = '\' + (Split-Path $task -Parent) + '\'
+
+        $existingTask = Get-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction SilentlyContinue
+
+        if ($null -ne $existingTask) {
+            Disable-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction Stop | Out-Null
+            Write-Host "[TASK] Disabled: $task" -ForegroundColor Green
+        } else {
+            Write-Host "[TASK] Not found: $task" -ForegroundColor Yellow
+        }
     } catch {
-        Write-Host "[TASK] Could not disable $task (may not exist)" -ForegroundColor Yellow
+        Write-Host "[TASK] Could not disable $task ($($_.Exception.Message))" -ForegroundColor Yellow
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid failing when telemetry tasks are not present

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483a427ec083329f3e4c2de144303e