### PR TITLE
Fix variable syntax in wallpaper script

### DIFF
--- a/includes/ZZZ-Set-WallpaperWithStats.ps1
+++ b/includes/ZZZ-Set-WallpaperWithStats.ps1
@@ -127,7 +127,7 @@ function Load-RegistryHive {
             Write-Log "Hive $HiveName in use. Waiting ($i/$MaxAttempts)..." -Color Yellow
             Start-Sleep -Seconds $DelaySeconds
         } else {
-            Write-Log "! Could not load hive $HiveName: $result" -Color Yellow
+            Write-Log "! Could not load hive ${HiveName}: ${result}" -Color Yellow
             return $false
         }
     }


### PR DESCRIPTION
## Summary
- escape variables in `ZZZ-Set-WallpaperWithStats.ps1`

## Testing
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684840395b388332b82d8a1e216cce89