### PR TITLE
Suppress missing key warnings

### DIFF
--- a/includes/Shared-Functions.ps1
+++ b/includes/Shared-Functions.ps1
@@ -79,7 +79,8 @@ function Remove-RegistryKey {
             Write-Host "[REGISTRY] Removed key: $Path" -ForegroundColor Yellow
             return $true
         } else {
-            Write-Host "[REGISTRY] Key not found (already removed): $Path" -ForegroundColor Gray
+            # Avoid noisy warnings if the key is already absent
+            Write-Log "[REGISTRY] Key not found (already removed): $Path"
             return $true
         }
     } catch {


### PR DESCRIPTION
## Summary
- quieten `Remove-RegistryKey` when registry key already removed

## Testing
- `powershell -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684842c8fc608332833643fef0255460