### PR TITLE
Add Set-FileAssoc fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,10 @@ The toolkit installs essential applications and sets up automated maintenance:
 - Runs as SYSTEM account for reliable execution
 - Generates update script at `C:\Scripts\Update-WingetApps.ps1`
 
-**File Association Management:**
-- Downloads and configures SetUserFTA.exe for reliable file associations (falls back to built-in `assoc` when incompatible)
+- **File Association Management:**
+- Downloads and configures SetUserFTA.exe for reliable file associations.
+- Falls back to the provided `Set-FileAssoc.ps1` script when SetUserFTA fails,
+  then to the built-in `assoc` command if needed.
 - Supports both Chrome-based (Google Workspace) and LibreOffice associations
 - Handles PDF, Office documents, and web protocols
 - Maintains consistency across user profiles
@@ -286,7 +288,7 @@ powershell -ExecutionPolicy Bypass .\customize-windows-client.ps1
 - Warns about potential lockout scenarios
 
 -**File Association Issues:**
-- Ensure `SetUserFTA.exe` downloaded successfully to `C:\Scripts\` (or rely on built-in fallback)
+- Ensure `SetUserFTA.exe` downloaded successfully to `C:\Scripts\`. The toolkit falls back to `Set-FileAssoc.ps1` and then `assoc` if needed
 - Verify target applications installed correctly
 - Run file association scripts after application installation
 - **Parsing Errors After Manual Extraction:**

--- a/includes/Set-FileAssoc.ps1
+++ b/includes/Set-FileAssoc.ps1
@@ -1,0 +1,17 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Extension,
+    [Parameter(Mandatory)][string]$ProgId
+)
+
+try {
+    $key = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\$Extension\UserChoice"
+    if (-not (Test-Path $key)) {
+        New-Item -Path $key -Force | Out-Null
+    }
+    Set-ItemProperty -Path $key -Name 'ProgId' -Value $ProgId -Force
+    Write-Host "Associated $Extension with $ProgId" -ForegroundColor Green
+} catch {
+    Write-Error "Failed to set association for $Extension : $_"
+    exit 1
+}

--- a/includes/Set-OfficeSuiteDefaults.ps1
+++ b/includes/Set-OfficeSuiteDefaults.ps1
@@ -10,9 +10,12 @@ $setUserFtaPath = Join-Path $env:TEMP 'SetUserFTA.exe'
 if (-not (Test-Path $setUserFtaPath)) {
     $setUserFtaPath = 'C:\Scripts\SetUserFTA.exe'
 }
-if (-not (Test-Path $setUserFtaPath)) {
-    Write-Warning "SetUserFTA.exe not found. File associations will be skipped."
-    Write-Log "SetUserFTA.exe missing for office defaults"
+
+$setFileAssocPath = Join-Path $PSScriptRoot 'Set-FileAssoc.ps1'
+
+if (-not (Test-Path $setUserFtaPath) -and -not (Test-Path $setFileAssocPath)) {
+    Write-Warning "SetUserFTA.exe and Set-FileAssoc.ps1 not found. File associations will be skipped."
+    Write-Log "No association tools available for office defaults"
     return
 }
 
@@ -52,7 +55,7 @@ switch ($choice) {
         Write-Host "Setting Google Workspace defaults..." -ForegroundColor Green
         foreach ($ext in $chromeMap.Keys) {
             try {
-                Set-FileAssociation -ExtensionOrProtocol $ext -ProgId $chromeMap[$ext] -SetUserFtaPath $setUserFtaPath
+                Set-FileAssociation -ExtensionOrProtocol $ext -ProgId $chromeMap[$ext] -SetUserFtaPath $setUserFtaPath -SetFileAssocPath $setFileAssocPath
             } catch {
                 Write-Warning "Failed to set association for $ext"
                 Write-Log "Association error for $ext : $_"
@@ -84,7 +87,7 @@ switch ($choice) {
         Write-Host "Setting LibreOffice defaults..." -ForegroundColor Green
         foreach ($ext in $libreOfficeMap.Keys) {
             try {
-                Set-FileAssociation -ExtensionOrProtocol $ext -ProgId $libreOfficeMap[$ext] -SetUserFtaPath $setUserFtaPath
+                Set-FileAssociation -ExtensionOrProtocol $ext -ProgId $libreOfficeMap[$ext] -SetUserFtaPath $setUserFtaPath -SetFileAssocPath $setFileAssocPath
             } catch {
                 Write-Warning "Failed to set association for $ext"
                 Write-Log "Association error for $ext : $_"

--- a/includes/Shared-Functions.ps1
+++ b/includes/Shared-Functions.ps1
@@ -247,7 +247,8 @@ function Set-FileAssociation {
     param(
         [Parameter(Mandatory)][string]$ExtensionOrProtocol,
         [Parameter(Mandatory)][string]$ProgId,
-        [string]$SetUserFtaPath = $(Join-Path $env:TEMP 'SetUserFTA.exe')
+        [string]$SetUserFtaPath    = $(Join-Path $env:TEMP 'SetUserFTA.exe'),
+        [string]$SetFileAssocPath  = $(Join-Path $PSScriptRoot 'Set-FileAssoc.ps1')
     )
 
     # Try SetUserFTA.exe first if available
@@ -266,6 +267,15 @@ function Set-FileAssociation {
             } else {
                 Write-Log "SetUserFTA failed for $ExtensionOrProtocol : $_"
             }
+        }
+    }
+
+    if ($useFallback -and (Test-Path $SetFileAssocPath)) {
+        try {
+            powershell.exe -NoProfile -ExecutionPolicy Bypass -File $SetFileAssocPath -Extension $ExtensionOrProtocol -ProgId $ProgId | Out-Null
+            $useFallback = $false
+        } catch {
+            Write-Log "Set-FileAssoc.ps1 failed for $ExtensionOrProtocol : $_"
         }
     }
 

--- a/includes/ZZ-Set-ChromeFileAssociations.ps1
+++ b/includes/ZZ-Set-ChromeFileAssociations.ps1
@@ -8,9 +8,12 @@ $setUserFtaPath = Join-Path $env:TEMP 'SetUserFTA.exe'
 if (-not (Test-Path $setUserFtaPath)) {
     $setUserFtaPath = 'C:\\Scripts\\SetUserFTA.exe'
 }
-if (-not (Test-Path $setUserFtaPath)) {
-    Write-Warning "SetUserFTA.exe not found. Skipping Chrome file associations."
-    Write-Log "SetUserFTA.exe missing for Chrome associations"
+
+$setFileAssocPath = Join-Path $PSScriptRoot 'Set-FileAssoc.ps1'
+
+if (-not (Test-Path $setUserFtaPath) -and -not (Test-Path $setFileAssocPath)) {
+    Write-Warning "SetUserFTA.exe and Set-FileAssoc.ps1 not found. Skipping Chrome file associations."
+    Write-Log "No association tools available for Chrome"
     return
 }
 
@@ -42,7 +45,7 @@ $associations = @{
 
 foreach ($type in $associations.Keys) {
     try {
-        Set-FileAssociation -ExtensionOrProtocol $type -ProgId $associations[$type] -SetUserFtaPath $setUserFtaPath
+        Set-FileAssociation -ExtensionOrProtocol $type -ProgId $associations[$type] -SetUserFtaPath $setUserFtaPath -SetFileAssocPath $setFileAssocPath
     } catch {
         Write-Warning "Failed to associate $type with Chrome"
         Write-Log "Association error for $type : $_"


### PR DESCRIPTION
## Summary
- add external `Set-FileAssoc.ps1` PowerShell script
- expand `Set-FileAssociation` function with Set-FileAssoc fallback
- update Chrome and Office defaults to use new parameter
- document file association fallback order

## Testing
- `pwsh -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848466ac74883328286fc06e7541b53