### PR TITLE
Fix scheduled task repetition

### DIFF
--- a/includes/Schedule-Daily-Shutdown.ps1
+++ b/includes/Schedule-Daily-Shutdown.ps1
@@ -27,26 +27,16 @@ Set-Content -Path $scriptPath -Value $scriptContent -Encoding UTF8 -Force
 Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
 
 # Create trigger: start at 9:00 PM and repeat every 15 minutes for 6 hours
-# Use a culture-invariant 24-hour time format to avoid localisation issues
-# when parsing the start time. Try to set the Repetition properties directly.
-# If that fails (for example on very old PowerShell builds), attempt to specify
-# them during creation. If that also fails, fall back to a simple daily trigger.
-$startTime = [datetime]::ParseExact('21:00', 'HH:mm', $null)
-$trigger   = New-ScheduledTaskTrigger -Daily -At $startTime
+# Use today's date to ensure a valid DateTime object across Windows builds
+$startTime = (Get-Date).Date.AddHours(21)
 try {
-    $trigger.Repetition.Interval  = New-TimeSpan -Minutes 15
-    $trigger.Repetition.Duration = New-TimeSpan -Hours 6
+    $trigger = New-ScheduledTaskTrigger -Daily -At $startTime `
+        -RepetitionInterval (New-TimeSpan -Minutes 15) `
+        -RepetitionDuration (New-TimeSpan -Hours 6)
 } catch {
-    Write-Log "Failed to set repetition property on shutdown trigger: $_"
-    try {
-        $trigger = New-ScheduledTaskTrigger -Daily -At $startTime `
-            -RepetitionInterval (New-TimeSpan -Minutes 15) `
-            -RepetitionDuration (New-TimeSpan -Hours 6)
-    } catch {
-        Write-Warning 'Failed to add repetition options. Task will run once per day at 9:00 PM.'
-        Write-Log "Fallback simple trigger created due to error: $_"
-        $trigger = New-ScheduledTaskTrigger -Daily -At $startTime
-    }
+    Write-Warning 'Failed to add repetition options. Task will run once per day at 9:00 PM.'
+    Write-Log "Fallback simple trigger created due to error: $_"
+    $trigger = New-ScheduledTaskTrigger -Daily -At $startTime
 }
 
 # Define action


### PR DESCRIPTION
## Summary
- update daily shutdown task to use a StartTime generated from today's date
- create trigger with repetition parameters directly

## Testing
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484b7216408332ae57520135cee2ee