### PR TITLE
Handle missing registry keys and tasks gracefully

### DIFF
--- a/includes/Hide-User-Folder-From-Desktop.ps1
+++ b/includes/Hide-User-Folder-From-Desktop.ps1
@@ -1,3 +1,16 @@
 # Hide User Folder shortcut from desktop
-Remove-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\ClassicStartMenu" -Name "{59031a47-3f72-44a7-89c5-5595fe6b30ee}"
-Remove-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel" -Name "{59031a47-3f72-44a7-89c5-5595fe6b30ee}"
+
+$userFolderGuid = '{59031a47-3f72-44a7-89c5-5595fe6b30ee}'
+$registryPaths = @(
+    'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\ClassicStartMenu',
+    'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel'
+)
+
+foreach ($path in $registryPaths) {
+    if (Test-Path $path -PathType Container -and \
+        (Get-ItemProperty -Path $path -Name $userFolderGuid -ErrorAction SilentlyContinue)) {
+        Remove-RegistryValue -Path $path -Name $userFolderGuid
+    } else {
+        Write-Host "[REGISTRY] Value not found (already removed): $path\$userFolderGuid" -ForegroundColor Gray
+    }
+}

--- a/includes/Strengthen-Privacy.ps1
+++ b/includes/Strengthen-Privacy.ps1
@@ -26,7 +26,7 @@ foreach ($task in $tasksToDisable) {
             Disable-ScheduledTask -TaskName $taskName -TaskPath $taskPath -ErrorAction Stop | Out-Null
             Write-Host "[TASK] Disabled: $task" -ForegroundColor Green
         } else {
-            Write-Host "[TASK] Not found: $task" -ForegroundColor Yellow
+            Write-Host "[TASK] Already absent: $task" -ForegroundColor Gray
         }
     } catch {
         Write-Host "[TASK] Could not disable $task ($($_.Exception.Message))" -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- check for registry value before removing in **Hide-User-Folder-From-Desktop.ps1**
- log when scheduled tasks are already absent in **Strengthen-Privacy.ps1**

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484b83398c83329fa079b329711e41