### PR TITLE
Fix if statement syntax in Hide-User-Folder-From-Desktop

### DIFF
--- a/includes/Hide-User-Folder-From-Desktop.ps1
+++ b/includes/Hide-User-Folder-From-Desktop.ps1
@@ -7,8 +7,7 @@ $registryPaths = @(
 )
 
 foreach ($path in $registryPaths) {
-    if (Test-Path $path -PathType Container -and \
-        (Get-ItemProperty -Path $path -Name $userFolderGuid -ErrorAction SilentlyContinue)) {
+    if (Test-Path $path -PathType Container -and (Get-ItemProperty -Path $path -Name $userFolderGuid -ErrorAction SilentlyContinue)) {
         Remove-RegistryValue -Path $path -Name $userFolderGuid
     } else {
         Write-Host "[REGISTRY] Value not found (already removed): $path\$userFolderGuid" -ForegroundColor Gray


### PR DESCRIPTION
## Summary
- correct multiline `if` statement that used an invalid line continuation

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `powershell -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485ab53cfc83329189c22f7816bb21