### PR TITLE
Fix line continuation in Hide-User-Folder-From-Desktop

### DIFF
--- a/includes/Hide-User-Folder-From-Desktop.ps1
+++ b/includes/Hide-User-Folder-From-Desktop.ps1
@@ -7,7 +7,8 @@ $registryPaths = @(
 )
 
 foreach ($path in $registryPaths) {
-    if (Test-Path $path -PathType Container -and (Get-ItemProperty -Path $path -Name $userFolderGuid -ErrorAction SilentlyContinue)) {
+    if (Test-Path $path -PathType Container -and `
+        (Get-ItemProperty -Path $path -Name $userFolderGuid -ErrorAction SilentlyContinue)) {
         Remove-RegistryValue -Path $path -Name $userFolderGuid
     } else {
         Write-Host "[REGISTRY] Value not found (already removed): $path\$userFolderGuid" -ForegroundColor Gray


### PR DESCRIPTION
## Summary
- fix PowerShell line continuation in `Hide-User-Folder-From-Desktop.ps1`

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684947d9c4448332a08e51c8889faeb8