### PR TITLE
Disable Windows 11 widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Bypa
 ### 🎨 Interface & User Experience
 
 **Taskbar & Start Menu Optimisation:**
-- Hides search box, Task View, and People icons
+- Hides search box, Task View, People, and Widgets icons
+- Disables Windows 11 Widgets feature
 - Shows small taskbar icons for space efficiency
 - Displays all system tray icons for better visibility
 - Removes recently and frequently used items from Explorer

--- a/apply-user-customizations.ps1
+++ b/apply-user-customizations.ps1
@@ -31,6 +31,7 @@ $userScripts = @(
     @{ Script = 'Hide-Recently-Shortcuts.ps1';       Description = 'Hide recently used shortcuts' },
     @{ Script = 'Hide-People-Icon-Taskbar.ps1';      Description = 'Hide People icon from taskbar' },
     @{ Script = 'Hide-Task-View-Button.ps1';         Description = 'Hide Task View button' },
+    @{ Script = 'Disable-Widgets.ps1';           Description = 'Disable Windows 11 widgets' },
     @{ Script = 'Hide-User-Folder-From-Desktop.ps1'; Description = 'Hide User Folder icon from desktop' },
     @{ Script = 'Show-All-Tray-Icons.ps1';           Description = 'Show all system tray icons' },
     @{ Script = 'Show-Small-Icons-in-Taskbar.ps1';   Description = 'Use small taskbar icons' },

--- a/includes/Disable-Widgets.ps1
+++ b/includes/Disable-Widgets.ps1
@@ -1,0 +1,16 @@
+# Disable Windows 11 Widgets
+
+# Hide Widgets button for the current user
+Set-RegistryValue -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "TaskbarDa" -Value 0 -Type "DWord" -Force
+
+# Apply system-wide policy to disable Widgets
+try {
+    $widgetsPolicy = "HKLM:\SOFTWARE\Policies\Microsoft\Dsh"
+    if (!(Test-Path $widgetsPolicy)) {
+        New-Item -Path $widgetsPolicy -Force | Out-Null
+    }
+    Set-ItemProperty -Path $widgetsPolicy -Name "AllowNewsAndInterests" -Type DWord -Value 0
+    Write-Host "[OK] Policy applied: Widgets disabled system-wide"
+} catch {
+    Write-Host "[WARN] Could not apply widgets policy: $($_.Exception.Message)"
+}


### PR DESCRIPTION
## Summary
- add script to disable Windows 11 Widgets
- reference Widgets in the README
- run widget disable step in user customizations

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `powershell -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494f60238083329586801a22845e46