### PR TITLE
Fix wallpaper cmd quoting

### DIFF
--- a/includes/ZZZ-Set-Wallpaper.ps1
+++ b/includes/ZZZ-Set-Wallpaper.ps1
@@ -54,7 +54,7 @@ if (-not $isPersisted) {
     Copy-Item -Path $PSCommandPath -Destination $PersistedScript -Force
 
     if (-not (Test-Path $StartupCmd)) {
-        $cmd = "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `\"$PersistedScript`\""
+        $cmd = "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$PersistedScript`""
         Set-Content -Path $StartupCmd -Value $cmd -Encoding ASCII
         Write-Host "Startup wallpaper reload configured." -ForegroundColor Green
     }


### PR DESCRIPTION
## Summary
- fix quoting error when persisting the wallpaper reload command

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684962925b248332b03a4cae18c1cbba