### PR TITLE
Fix Test-Path condition in Hide-User-Folder script

### DIFF
--- a/includes/Hide-User-Folder-From-Desktop.ps1
+++ b/includes/Hide-User-Folder-From-Desktop.ps1
@@ -7,7 +7,7 @@ $registryPaths = @(
 )
 
 foreach ($path in $registryPaths) {
-    if (Test-Path $path -PathType Container -and `
+    if ((Test-Path $path -PathType Container) -and
         (Get-ItemProperty -Path $path -Name $userFolderGuid -ErrorAction SilentlyContinue)) {
         Remove-RegistryValue -Path $path -Name $userFolderGuid
     } else {


### PR DESCRIPTION
## Summary
- fix the conditional logic in `Hide-User-Folder-From-Desktop.ps1`

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684962bf445c8332b5ea7d06838fe6b9