### PR TITLE
Fix admin error during widget disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The toolkit includes automatic restore point creation and registry backup, but t
 
 ### Method 1: One-Command Installation
 
-Open **PowerShell as Administrator** and execute:
+Open **PowerShell as Administrator** and execute (the script will attempt to self-elevate if you forget):
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iwr -useb https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1 | iex; & `"$env:USERPROFILE\Downloads\customize-windows-setup\customize-windows-setup-main\customize-windows-client.ps1`""

--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -70,10 +70,11 @@ if(!(Test-Path $TEMPFOLDER)) {
     New-Item -ItemType Directory -Force -Path $TEMPFOLDER | Out-Null
 }
 
-if(-not (Test-Administrator)) {
-    Write-Error "This script must be executed as Administrator.";
-    Read-Host "Press ENTER to continue..."
-    exit 1;
+if (-not (Test-Administrator)) {
+    Write-Host "[INFO] Re-launching with administrative privileges..." -ForegroundColor Yellow
+    $quotedArgs = $MyInvocation.UnboundArguments | ForEach-Object { '"' + $_ + '"' } -join ' '
+    Start-Process -FilePath "powershell.exe" -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`" $quotedArgs" -Verb RunAs
+    exit
 }
 
 # Start logging the console output

--- a/includes/Disable-Widgets.ps1
+++ b/includes/Disable-Widgets.ps1
@@ -4,13 +4,9 @@
 Set-RegistryValue -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "TaskbarDa" -Value 0 -Type "DWord" -Force
 
 # Apply system-wide policy to disable Widgets
-try {
-    $widgetsPolicy = "HKLM:\SOFTWARE\Policies\Microsoft\Dsh"
-    if (!(Test-Path $widgetsPolicy)) {
-        New-Item -Path $widgetsPolicy -Force | Out-Null
-    }
-    Set-ItemProperty -Path $widgetsPolicy -Name "AllowNewsAndInterests" -Type DWord -Value 0
+$widgetsPolicy = "HKLM:\SOFTWARE\Policies\Microsoft\Dsh"
+if (Set-RegistryValue -Path $widgetsPolicy -Name "AllowNewsAndInterests" -Value 0 -Type "DWord" -Force) {
     Write-Host "[OK] Policy applied: Widgets disabled system-wide"
-} catch {
-    Write-Host "[WARN] Could not apply widgets policy: $($_.Exception.Message)"
+} else {
+    Write-Host "[WARN] Could not apply widgets policy" -ForegroundColor Yellow
 }


### PR DESCRIPTION
## Summary
- auto-elevate `customize-windows-client.ps1` when not run as admin
- handle registry write in `Disable-Widgets.ps1` via helper
- clarify quick start instructions about self-elevation

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684968b9d85483328f5fe4f8ee8514b3