### PR TITLE
Fix variable expansion in registry backup warnings

### DIFF
--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -130,9 +130,9 @@ foreach ($hive in $regBackupFiles.Keys) {
             throw "Registry export for $hive failed"
         }
     } catch {
-        Write-Warning "Failed to backup registry hive $hive: $_"
+        Write-Warning "Failed to backup registry hive ${hive}: $_"
         $ScriptSuccess = $false
-        $ErrorMessages += "Registry backup $hive: $_"
+        $ErrorMessages += "Registry backup ${hive}: $_"
     }
 }
 # Start customization


### PR DESCRIPTION
## Summary
- fix invalid variable references in registry backup messages

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7429dc5c83328834b49950fe2ade