### PR TITLE
Remove interactive prompts

### DIFF
--- a/apply-user-customizations.ps1
+++ b/apply-user-customizations.ps1
@@ -69,5 +69,4 @@ $results = foreach ($s in $userScripts) {
 $success = ($results | Where-Object Success).Count
 $total   = $results.Count
 Write-Host "`nCompleted $success of $total user customizations." -ForegroundColor $(if($success -eq $total){'Green'}else{'Yellow'})
-
-Read-Host "`nPress Enter to exit..."
+Write-Host "User customizations complete."

--- a/includes/ZZ-Disable-MicrosoftAccount.ps1
+++ b/includes/ZZ-Disable-MicrosoftAccount.ps1
@@ -1,5 +1,9 @@
 # Disable Microsoft account sign-in prompts and account creation
 
+param(
+    [switch]$Force
+)
+
 # Check if the current profile is associated with a Microsoft account
 $identitiesPath = 'HKCU:\SOFTWARE\Microsoft\IdentityCRL\StoredIdentities'
 $identityFound = Test-Path $identitiesPath
@@ -28,24 +32,21 @@ if ($hasMicrosoftAccount) {
     }
     else {
         Write-Warning 'No additional local accounts were found.'
-        $create = Read-Host 'Would you like to create a local account now? [y/N]'
-        if ($create -eq 'y') {
-            $username = New-LocalUserAccount -AccountType 'Administrator'
-            if ($null -ne $username) { $hasLocalAccount = $true }
+        if (-not $Force) {
+            Write-Warning 'Skipping Microsoft account changes to avoid lockout. Use -Force to override.'
+            return
         }
     }
 
-    $confirmation = Read-Host 'Disable Microsoft account features? [y/N]'
-    if ($confirmation -ne 'y') {
-        Write-Host 'Microsoft account changes skipped.'
-        return
+    if (-not $Force) {
+        Write-Host 'Proceeding to disable Microsoft account features.'
     }
 } else {
-    $confirmation = Read-Host 'No Microsoft account detected. Disable Microsoft account features anyway? [y/N]'
-    if ($confirmation -ne 'y') {
-        Write-Host 'Microsoft account changes skipped.'
+    if (-not $Force) {
+        Write-Host 'No Microsoft account detected. Skipping Microsoft account changes.'
         return
     }
+    Write-Host 'No Microsoft account detected, but -Force specified. Disabling features anyway.'
 }
 
 # Block Microsoft account sign-in prompts


### PR DESCRIPTION
## Summary
- convert `ZZ-Disable-MicrosoftAccount.ps1` to run without `Read-Host`
- remove pause prompt from `apply-user-customizations.ps1`

## Testing
- `powershell` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e792d2884833291b3340103d2565f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional "Force" mode to the Microsoft account disabling script, allowing non-interactive execution without confirmation prompts.

* **Improvements**
  * Streamlined user experience by removing unnecessary prompts at the end of the customization script, providing immediate completion feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->