### PR TITLE
Use explicit .exe suffix for system tools

### DIFF
--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -125,7 +125,7 @@ $regBackupFiles = @{
 foreach ($hive in $regBackupFiles.Keys) {
     $file = $regBackupFiles[$hive]
     try {
-        reg export $hive $file /y
+        reg.exe export $hive $file /y
         if ($LASTEXITCODE -ne 0 -or -not (Test-Path $file) -or (Get-Item $file).Length -eq 0) {
             throw "Registry export for $hive failed"
         }

--- a/includes/Configure-AccountLockout.ps1
+++ b/includes/Configure-AccountLockout.ps1
@@ -1,11 +1,11 @@
 # Account lockout policy
 
 # Number of failed login attempts before the account is locked
-net accounts /lockoutthreshold:5
+net.exe accounts /lockoutthreshold:5
 
 # Duration (in minutes) that the account remains locked out
-net accounts /lockoutduration:30
+net.exe accounts /lockoutduration:30
 
 # Time window (in minutes) during which failed login attempts are counted
 # If 5 failed attempts occur within this 30-minute window, the account is locked
-net accounts /lockoutwindow:30
+net.exe accounts /lockoutwindow:30

--- a/includes/Disable-Guest-Account.ps1
+++ b/includes/Disable-Guest-Account.ps1
@@ -1,2 +1,2 @@
 ## Disable guest account
-net user guest /active:no
+net.exe user guest /active:no

--- a/includes/Disable-Hibernation.ps1
+++ b/includes/Disable-Hibernation.ps1
@@ -1,3 +1,3 @@
 # Disable hibernation (reclaims disk space, avoids hybrid sleep issues)
-powercfg -h off
+powercfg.exe -h off
 Write-Host "[OK] Hibernation disabled to prevent hybrid sleep and reclaim disk space."

--- a/includes/Enable-WakeOnLan.ps1
+++ b/includes/Enable-WakeOnLan.ps1
@@ -21,9 +21,9 @@ Get-NetAdapter | Where-Object {
 
     # Set power management options
     try {
-        powercfg -devicequery wake_from_any | Where-Object { $_ -like "*$adapterName*" } | ForEach-Object {
-            powercfg -devicedisablewake $_
-            powercfg -deviceenablewake $_
+        powercfg.exe -devicequery wake_from_any | Where-Object { $_ -like "*$adapterName*" } | ForEach-Object {
+            powercfg.exe -devicedisablewake $_
+            powercfg.exe -deviceenablewake $_
         }
         Write-Host "[OK] Enabled wake permissions in power management for $adapterName"
     } catch {

--- a/includes/Set-PasswordPolicy.ps1
+++ b/includes/Set-PasswordPolicy.ps1
@@ -1,7 +1,7 @@
 # Disable password expiration
-net accounts /maxpwage:unlimited
+net.exe accounts /maxpwage:unlimited
 
 # Set minimum password length and complexity
 # Reduced from 8 to 7 per new requirements
-net accounts /minpwlen:7
-net accounts /uniquepw:5       # Optional: Prevents recent password reuse
+net.exe accounts /minpwlen:7
+net.exe accounts /uniquepw:5       # Optional: Prevents recent password reuse


### PR DESCRIPTION
## Summary
- explicitly call `net.exe`, `powercfg.exe`, and `reg.exe`
- update scripts that manage account lockout, password policy, guest account, and power settings
- ensure registry backup uses `reg.exe`

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7f6ae0cc8332be47384f4ddd141c