### PR TITLE
Use C:\Temp and remove OneDrive for all profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The toolkit includes automatic restore point creation and registry backup, but t
 Open **PowerShell as Administrator** and execute (the script will attempt to self-elevate if you forget):
 
 ```powershell
- Set-ExecutionPolicy Bypass -Scope Process -Force; iwr -useb https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1 | iex; & "$env:USERPROFILE\Downloads\customize-windows-setup\customize-windows-setup-main\customize-windows-client.ps1"
+ Set-ExecutionPolicy Bypass -Scope Process -Force; iwr -useb https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1 | iex; & "C:\Temp\customize-windows-setup\customize-windows-setup-main\customize-windows-client.ps1"
 ```
 
 ### Method 2: Manual Installation
@@ -37,13 +37,13 @@ Open **PowerShell as Administrator** and execute (the script will attempt to sel
    ```
 3. **Download repository:**
    ```powershell
-   $downloadPath = Join-Path $env:USERPROFILE 'Downloads'
+   $downloadPath = 'C:\\Temp'
    iwr -Uri 'https://raw.githubusercontent.com/ShaheedFazal/customize-windows-setup/main/download-repo.ps1' -OutFile (Join-Path $downloadPath 'download-repo.ps1')
    & "$downloadPath\download-repo.ps1"
    ```
 4. **Execute the toolkit:**
    ```powershell
-   cd "$env:USERPROFILE\Downloads\customize-windows-setup\customize-windows-setup-main"
+   cd "C:\\Temp\\customize-windows-setup\\customize-windows-setup-main"
    .\customize-windows-client.ps1
    ```
    The script runs **interactively** and will pause for user input at several steps.
@@ -99,6 +99,7 @@ Open **PowerShell as Administrator** and execute (the script will attempt to sel
 - Complete OneDrive uninstallation with registry cleanup
 - Removes OneDrive from File Explorer integration
 - Cleans up leftover folders and shortcuts
+- Moves each user's OneDrive files into their Documents folder before removal
 - Alternative: OneDrive disable-only option available
 
 ### ⚙️ System Optimisation & Performance

--- a/download-repo.ps1
+++ b/download-repo.ps1
@@ -35,10 +35,13 @@ if ($executionPolicy -eq 'Restricted') {
 
 # Choose a sensible base path when the script is invoked via a one-liner.
 # A direct `iex` call often starts in the Windows system directory, so
-# default to the user's Downloads folder in that case.
+# default to C:\Temp in that case.
 $basePath = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
 if ($basePath -like "$env:windir*") {
-    $basePath = Join-Path $env:USERPROFILE 'Downloads'
+    $basePath = 'C:\\Temp'
+}
+if (!(Test-Path $basePath)) {
+    New-Item -ItemType Directory -Force -Path $basePath | Out-Null
 }
 
 # Path to store the downloaded zip


### PR DESCRIPTION
## Summary
- default repository extraction path to `C:\Temp`
- update README usage instructions for the new location
- remove OneDrive folders from all user profiles, moving files into Documents first

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686e9ff70b948332b0ff5139702afc00

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The toolkit now moves each user's OneDrive files into their Documents folder before removing OneDrive, improving data preservation during cleanup.

* **Documentation**
  * Updated instructions to use C:\Temp as the default directory for downloads and script execution instead of the Downloads folder.
  * Added details about the new OneDrive file migration step in the user guide.

* **Bug Fixes**
  * Improved OneDrive cleanup to dynamically handle all user profiles, ensuring more thorough and reliable file removal and migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->