### PR TITLE
Update Microsoft account blocking behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Open **PowerShell as Administrator** and execute (the script will attempt to sel
 - Blocks feedback collection and user experience improvement programmes
 
 **Microsoft Account & Authentication:**
-- Intelligently blocks Microsoft account sign-in prompts with safety checks
+- Always blocks Microsoft account sign-in prompts to prevent accidental account creation (safety checks run if an account is detected)
 - Disables Windows Hello for Business (with local account verification)
 - Prevents Microsoft 365 promotional notifications
 - Offers guided local account creation for safety
@@ -68,7 +68,7 @@ Open **PowerShell as Administrator** and execute (the script will attempt to sel
 ### 🛡️ Privacy & Security Enhancements
 - **Disables telemetry and data collection** across Windows components
 - **Removes advertising ID** and content suggestions
-- **Blocks Microsoft account sign-in prompts** (with safety checks)
+- **Blocks Microsoft account sign-in prompts** even when no account is present
 - **Enables BitLocker encryption** with automatic key backup
 - **Configures Windows Defender** with optimal settings
 - **Enables SmartScreen (App & Browser Control)** for safer downloads
@@ -268,6 +268,7 @@ powershell -ExecutionPolicy Bypass .\customize-windows-client.ps1
 - Toolkit detects existing Microsoft accounts
 - Prompts for local account creation before proceeding
 - Warns about potential lockout scenarios
+- Disables Microsoft account sign-in even when no Microsoft account is present
 
 - **Parsing Errors After Manual Extraction:**
   - Some third-party unzip tools can corrupt PowerShell files

--- a/includes/ZZ-Disable-MicrosoftAccount.ps1
+++ b/includes/ZZ-Disable-MicrosoftAccount.ps1
@@ -43,10 +43,10 @@ if ($hasMicrosoftAccount) {
     }
 } else {
     if (-not $Force) {
-        Write-Host 'No Microsoft account detected. Skipping Microsoft account changes.'
-        return
+        Write-Host 'No Microsoft account detected. Disabling sign-in features to prevent accidental account addition.'
+    } else {
+        Write-Host 'No Microsoft account detected, but -Force specified. Disabling features anyway.'
     }
-    Write-Host 'No Microsoft account detected, but -Force specified. Disabling features anyway.'
 }
 
 # Block Microsoft account sign-in prompts


### PR DESCRIPTION
## Summary
- prevent accidental Microsoft account use by always disabling sign-in features
- document new default behavior

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8cbe2f588332804c74372f2295e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that Microsoft account sign-in prompts are always blocked, regardless of account presence, and revised privacy and security notes to reflect this behavior.
  * Enhanced troubleshooting guidance to emphasize the more aggressive blocking approach.

* **Bug Fixes**
  * Adjusted toolkit behavior to always disable Microsoft account sign-in features, even when no Microsoft account is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->