### PR TITLE
Fix OneDrive Start menu icon removal

### DIFF
--- a/includes/Uninstall-OneDrive.ps1
+++ b/includes/Uninstall-OneDrive.ps1
@@ -90,6 +90,35 @@ if ($onedriveInstalled) {
         }
     }
 
+    # Remove Start Menu shortcuts created by OneDrive
+    Write-Host "[INFO] Cleaning up OneDrive Start Menu shortcuts..."
+
+    $commonStartMenu = Join-Path $env:ProgramData 'Microsoft\\Windows\\Start Menu\\Programs'
+    if (Test-Path $commonStartMenu) {
+        Get-ChildItem -Path $commonStartMenu -Filter 'OneDrive*.lnk' -ErrorAction SilentlyContinue | ForEach-Object {
+            try {
+                Remove-Item -Path $_.FullName -Force -ErrorAction Stop
+                Write-Host "[OK] Removed shortcut: $($_.FullName)" -ForegroundColor Green
+            } catch {
+                Write-Host "[WARN] Could not remove shortcut: $($_.FullName) - $_" -ForegroundColor Yellow
+            }
+        }
+    }
+
+    foreach ($profile in $profiles) {
+        $userStartMenu = Join-Path $profile.FullName 'AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs'
+        if (Test-Path $userStartMenu) {
+            Get-ChildItem -Path $userStartMenu -Filter 'OneDrive*.lnk' -ErrorAction SilentlyContinue | ForEach-Object {
+                try {
+                    Remove-Item -Path $_.FullName -Force -ErrorAction Stop
+                    Write-Host "[OK] Removed user shortcut: $($_.FullName)" -ForegroundColor Green
+                } catch {
+                    Write-Host "[WARN] Could not remove user shortcut: $($_.FullName) - $_" -ForegroundColor Yellow
+                }
+            }
+        }
+    }
+
     # Clean up registry shell extensions
     if (-not (Get-PSDrive -Name "HKCR" -ErrorAction SilentlyContinue)) {
         New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT -ErrorAction SilentlyContinue | Out-Null


### PR DESCRIPTION
## Summary
- remove leftover OneDrive Start Menu shortcuts during uninstall

## Testing
- `powershell -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f93241edc833290784d39710f9436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically removes OneDrive-related Start Menu shortcuts for all users after OneDrive is uninstalled.

* **Enhancements**
  * Improved cleanup process to ensure Start Menu entries are deleted, providing a more thorough uninstallation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->