### PR TITLE
Disable wallpaper modification script

### DIFF
--- a/apply-user-customizations.ps1
+++ b/apply-user-customizations.ps1
@@ -34,7 +34,6 @@ $userScripts = @(
     @{ Script = 'Hide-All-Tray-Icons.ps1';           Description = 'Hide all system tray icons' },
     @{ Script = 'Show-Small-Icons-in-Taskbar.ps1';   Description = 'Use small taskbar icons' },
     @{ Script = 'Set-Control-Panel-View-to-Small-Icons.ps1'; Description = 'Set Control Panel to small icons' },
-    @{ Script = 'ZZ-Set-Wallpaper.ps1';    Description = 'Set Wallpaper' }
 )
 
 function Invoke-UserScript {


### PR DESCRIPTION
## Summary
- prevent wallpaper modification by removing `ZZ-Set-Wallpaper.ps1` from the user customizations list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fc9c92f308332a19ddc2beaebae27