### PR TITLE
Adjust password policy and disable script

### DIFF
--- a/includes/Set-PasswordPolicy.ps1
+++ b/includes/Set-PasswordPolicy.ps1
@@ -1,7 +1,0 @@
-# Disable password expiration
-net.exe accounts /maxpwage:unlimited
-
-# Set minimum password length and complexity
-# Reduced from 8 to 7 per new requirements
-net.exe accounts /minpwlen:7
-net.exe accounts /uniquepw:5       # Optional: Prevents recent password reuse

--- a/includes/disabled/Set-PasswordPolicy.ps1
+++ b/includes/disabled/Set-PasswordPolicy.ps1
@@ -1,0 +1,6 @@
+# Disable password expiration
+net.exe accounts /maxpwage:unlimited
+
+# Strengthen password requirements in line with security baselines
+net.exe accounts /minpwlen:14     # Minimum length of 14 characters
+net.exe accounts /uniquepw:24     # Remember last 24 passwords to prevent reuse


### PR DESCRIPTION
## Summary
- strengthen password policy defaults
- move Set-PasswordPolicy script to disabled folder

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702adaf368833282ca478b3a3593ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Moved the password policy configuration script to a disabled directory.
  * Updated the script to enforce a minimum password length of 14 characters and prevent reuse of the last 24 passwords.
  * Password expiration remains disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->