### PR TITLE
Handle recent restore points

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ These scripts make extensive changes to the operating system. Before running the
 - **Review the scripts** in the `includes` directory to understand what will change.
 - **Test on a non-production machine** whenever possible.
 - **Run PowerShell as Administrator** to ensure all steps succeed.
+- **System restore points** are limited by the `SystemRestorePointCreationFrequency` registry value (24 hours by default). The script skips creating a new point if a recent one already exists.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- check the `SystemRestorePointCreationFrequency` registry setting in `customize-windows-client.ps1`
- skip restore point creation when a recent point exists
- note the 24‑hour limitation in the README

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `powershell -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702f287fe48332b0670cec4be84de5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The script now checks the configured frequency for system restore point creation and skips creating a new restore point if a recent one exists, providing an informational message.

* **Documentation**
  * Updated the README to explain the new restore point frequency behavior and its configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->