### PR TITLE
Fix undefined color variable and update catch block

### DIFF
--- a/includes/Set-PowerManagement-HighPerformance.ps1
+++ b/includes/Set-PowerManagement-HighPerformance.ps1
@@ -5,5 +5,5 @@
     $currPlan = $(powercfg -getactivescheme).split()[3]
     if ($currPlan -ne $highPerf) {powercfg -setactive $highPerf}
 } Catch {
-    Write-Warning -Message "Unable to set power plan to $POWERMANAGEMENT" -foregroundcolor $foregroundColor2
+    Write-Warning -Message "Unable to set power plan to $POWERMANAGEMENT" -foregroundcolor $FOREGROUNDCOLOR
 }


### PR DESCRIPTION
## Summary
- replace `$foregroundColor2` with the globally defined `$FOREGROUNDCOLOR` in `Set-PowerManagement-HighPerformance.ps1`

## Testing
- `pwsh -NoProfile -File includes/Set-PowerManagement-HighPerformance.ps1` *(fails: command not found)*
- `powershell -NoProfile -File includes/Set-PowerManagement-HighPerformance.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702f3d9e0883328e766cdcf40211b2