### PR TITLE
Improve Widgets icon script handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The main script walks through each module in `includes/`, applying changes in al
 - **Application install** – installs common utilities like PowerShell 7, VLC, and other tools via `winget`.
 - **System tweaks** – switches to the High Performance power plan, adjusts Explorer and taskbar settings and applies a custom wallpaper.
 - **Server support** – includes logic for Windows Server editions with appropriate defaults.
+- **Widgets customization** – hides the Widgets icon from the taskbar by writing policy values under `HKLM\SOFTWARE\Microsoft\PolicyManager\default\NewsAndInterests\AllowNewsAndInterests` and `HKLM\SOFTWARE\Policies\Microsoft\Dsh`. On some systems UAC or group policy may block this change; run PowerShell as Administrator or adjust policies if needed.
 
 A full list of scripts can be found in the `includes/` folder. Move any script into `includes/disabled/` to skip it during execution.
 

--- a/includes/Hide-Widgets-Icon.ps1
+++ b/includes/Hide-Widgets-Icon.ps1
@@ -1,2 +1,20 @@
-# Hide Widgets icon on the taskbar
-Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "TaskbarDa" -Value 0 -Type "DWord" -Force
+# Hide Widgets icon on the taskbar for all users using policy keys
+Write-Host "Hiding Widgets icon on the taskbar system-wide..."
+
+$policyManagerPath = "HKLM:\SOFTWARE\Microsoft\PolicyManager\default\NewsAndInterests\AllowNewsAndInterests"
+$dshPolicyPath     = "HKLM:\SOFTWARE\Policies\Microsoft\Dsh"
+
+try {
+    # Confirm the policy path is writable
+    $regKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SOFTWARE\Microsoft\PolicyManager\default\NewsAndInterests\AllowNewsAndInterests', $true)
+    if (-not $regKey) {
+        throw "Registry path could not be opened with write access"
+    }
+    $regKey.Close()
+
+    Set-RegistryValue -Path $policyManagerPath -Name "value" -Value 0 -Type "DWord" -Force
+    Set-RegistryValue -Path $dshPolicyPath -Name "AllowNewsAndInterests" -Value 0 -Type "DWord" -Force
+    Write-Host "[OK] Policy applied: Widgets icon hidden"
+} catch {
+    Write-Warning "Unable to modify Widgets policy settings. UAC or group policy may restrict write access. Try running PowerShell as Administrator. $_"
+}


### PR DESCRIPTION
## Summary
- check for write access to HKLM policy path before hiding Widgets icon
- write updated policy values in Hide-Widgets-Icon.ps1
- note updated registry keys in README

## Testing
- `pwsh -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702f3701c8833295c9737e023b17f5