### PR TITLE
Enforce tray icon behavior via policy registry

### DIFF
--- a/includes/Hide-All-Tray-Icons.ps1
+++ b/includes/Hide-All-Tray-Icons.ps1
@@ -1,2 +1,2 @@
 # Hide all tray icons
-Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" -Name "EnableAutoTray" -Value 1 -Type "DWord" -Force
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "EnableAutoTray" -Value 1 -Type "DWord" -Force

--- a/includes/disabled/Show-All-Tray-Icons.ps1
+++ b/includes/disabled/Show-All-Tray-Icons.ps1
@@ -1,2 +1,2 @@
 # Show all tray icons
-Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" -Name "EnableAutoTray" -Value 0 -Type "DWord" -Force
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "NoAutoTrayNotify" -Value 1 -Type "DWord" -Force


### PR DESCRIPTION
## Summary
- ensure tray icons can be hidden for all users by writing EnableAutoTray under policy registry
- allow showing all tray icons for everyone via NoAutoTrayNotify policy value

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894aaf63eec8332aa0f40f597130e83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated system settings to apply tray icon visibility changes at the machine-wide policy level instead of per-user.
  * Adjusted registry modifications to use new policy-based paths for hiding or showing all tray icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->