### PR TITLE
Disable Game DVR via policy

### DIFF
--- a/includes/Disable-XBox.ps1
+++ b/includes/Disable-XBox.ps1
@@ -4,5 +4,16 @@ Get-AppxPackage "Microsoft.XboxIdentityProvider" | Remove-AppxPackage -ErrorActi
 Get-AppxPackage "Microsoft.XboxSpeechToTextOverlay" | Remove-AppxPackage
 Get-AppxPackage "Microsoft.XboxGameOverlay" | Remove-AppxPackage
 Get-AppxPackage "Microsoft.Xbox.TCUI" | Remove-AppxPackage
-Set-RegistryValue -Path "HKCU:\System\GameConfigStore" -Name "GameDVR_Enabled" -Value 0 -Type "DWord"
+# Apply system-wide policy to disable Game DVR
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\GameDVR" -Name "AllowGameDVR" -Value 0 -Type "DWord"
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR" -Name "value" -Value 0 -Type "DWord"
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager\current\ApplicationManagement\AllowGameDVR" -Name "value" -Value 0 -Type "DWord"
+
+# Clean up any per-user Game DVR settings
+$hives = Get-ChildItem 'Registry::HKEY_USERS' | Where-Object { $_.PSChildName -match '^S-1-5-' -and $_.PSChildName -notmatch '_Classes$' }
+foreach ($hive in $hives) {
+    $userPath = "Registry::$($hive.PSChildName)\System\GameConfigStore"
+    Remove-RegistryValue -Path $userPath -Name 'GameDVR_Enabled'
+}
+
+Remove-RegistryValue -Path 'HKU:\.DEFAULT\System\GameConfigStore' -Name 'GameDVR_Enabled'


### PR DESCRIPTION
## Summary
- remove per-user GameDVR registry tweak
- enforce Game DVR disablement via HKLM policy keys
- clean existing user hives of GameDVR setting

## Testing
- `pwsh --version` *(fails: command not found)*
- `powershell --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894aaf7b56483328a7a81fb6774161f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of disabling Game DVR by applying system-wide policy settings.
  * Ensured removal of existing per-user Game DVR settings for all users, including the default user profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->