### PR TITLE
Enforce visible file extensions via HKLM policy

### DIFF
--- a/HKCU-to-HKLM-Migration.md
+++ b/HKCU-to-HKLM-Migration.md
@@ -57,3 +57,9 @@ accounts.
 - **New:** `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer\SearchBoxTaskbarMode = 0`
 - **Impact:** ensures the taskbar search box stays hidden system-wide.
 - **Rollback:** delete the HKLM policy value or set it to `1` or `2` to restore the search icon or box.
+
+## Show-Known-File-Extensions.ps1
+- **Old:** `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\HideFileExt = 0`
+- **New:** `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer\HideFileExt = 0`
+- **Impact:** forces file extensions to remain visible for all users.
+- **Rollback:** delete the HKLM policy value and re-create per-user preferences if needed.

--- a/includes/Show-Known-File-Extensions.ps1
+++ b/includes/Show-Known-File-Extensions.ps1
@@ -1,2 +1,4 @@
-# Showing known file extensions
-Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "HideFileExt" -Type DWord -Value 0
+# Show known file extensions system-wide
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "HideFileExt" -Value 0 -Type "DWord" -Force
+Remove-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "HideFileExt"
+


### PR DESCRIPTION
## Summary
- Replace per-user HideFileExt tweak with system-wide policy under HKLM.
- Remove conflicting HKCU value to ensure file extensions stay visible.
- Document migration of file extension visibility setting to HKLM.

## Testing
- `pwsh -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion'` *(failed: command not found)*
- `apt-get update` *(failed: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894aafc2a588332b31ad77322875af0