### PR TITLE
Apply policy to hide People icon

### DIFF
--- a/includes/Hide-People-Icon-Taskbar.ps1
+++ b/includes/Hide-People-Icon-Taskbar.ps1
@@ -1,2 +1,5 @@
-# Hide Taskbar People icon
-Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\People" -Name "PeopleBand" -Value 0 -Type "DWord" -Force
+# Hide Taskbar People icon via policy for all users
+# Apply system-wide policy and remove any per-user setting
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer\Advanced\People" -Name "PeopleBand" -Value 0 -Type "DWord" -Force
+Remove-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\People" -Name "PeopleBand"
+


### PR DESCRIPTION
## Summary
- enforce PeopleBand policy under HKLM to hide People icon
- remove per-user PeopleBand value so policy takes precedence

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` (command not found)
- `apt-get update` (403 Forbidden)
- `apt-get install -y powershell` (unable to locate package)


------
https://chatgpt.com/codex/tasks/task_e_6894aafe2d248332a285e035a5021182