### PR TITLE
Use policy for taskbar small icons

### DIFF
--- a/HKCU-to-HKLM-Migration.md
+++ b/HKCU-to-HKLM-Migration.md
@@ -57,3 +57,9 @@ accounts.
 - **New:** `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer\SearchBoxTaskbarMode = 0`
 - **Impact:** ensures the taskbar search box stays hidden system-wide.
 - **Rollback:** delete the HKLM policy value or set it to `1` or `2` to restore the search icon or box.
+
+## Show-Small-Icons-in-Taskbar.ps1
+- **Old:** `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\TaskbarSmallIcons = 1`
+- **New:** `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer\TaskbarSmallIcons = 1`
+- **Impact:** enforces small taskbar icons for every account without per-user overrides.
+- **Rollback:** remove the HKLM policy value or set it to `0` to restore default icon size.

--- a/includes/Show-Small-Icons-in-Taskbar.ps1
+++ b/includes/Show-Small-Icons-in-Taskbar.ps1
@@ -1,2 +1,2 @@
 # Show small icons in taskbar
-Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "TaskbarSmallIcons" -Value 1 -Type "DWord" -Force
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "TaskbarSmallIcons" -Value 1 -Type "DWord" -Force

--- a/includes/disabled/apply-user-customizations.ps1
+++ b/includes/disabled/apply-user-customizations.ps1
@@ -32,7 +32,6 @@ $userScripts = @(
     @{ Script = 'Hide-Widgets-Icon.ps1';             Description = 'Hide Widgets icon from taskbar' },
     @{ Script = 'Hide-User-Folder-From-Desktop.ps1'; Description = 'Hide User Folder icon from desktop' },
     @{ Script = 'Hide-All-Tray-Icons.ps1';           Description = 'Hide all system tray icons' },
-    @{ Script = 'Show-Small-Icons-in-Taskbar.ps1';   Description = 'Use small taskbar icons' },
     @{ Script = 'Set-Control-Panel-View-to-Small-Icons.ps1'; Description = 'Set Control Panel to small icons' },
     @{ Script = 'ZZ-Set-Wallpaper.ps1';    Description = 'Set Wallpaper' }
 )


### PR DESCRIPTION
## Summary
- enforce small taskbar icons via HKLM Explorer policy
- drop per-user taskbar icon script from user customizations
- document TaskbarSmallIcons HKLM policy migration

## Testing
- `pwsh -Version` *(fails: command not found)*
- `powershell -Version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894aaffc5548332834dab1c324709ba