### PR TITLE
Configure Explorer recent items policy

### DIFF
--- a/includes/Hide-Recently-Shortcuts.ps1
+++ b/includes/Hide-Recently-Shortcuts.ps1
@@ -1,3 +1,0 @@
-# Hide recently and frequently used item shortcuts in Explorer
-Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" -Name "ShowRecent" -Value 0 -Type "DWord" -Force
-Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" -Name "ShowFrequent" -Value 0 -Type "DWord" -Force

--- a/includes/Show-Recently-Shortcuts.ps1
+++ b/includes/Show-Recently-Shortcuts.ps1
@@ -1,0 +1,7 @@
+# Show recently and frequently used item shortcuts in Explorer
+$explorerPolicyPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer"
+if (!(Test-Path $explorerPolicyPath)) {
+    New-Item -Path $explorerPolicyPath -Force | Out-Null
+}
+Set-RegistryValue -Path $explorerPolicyPath -Name "ShowRecent" -Value 1 -Type "DWord" -Force
+Set-RegistryValue -Path $explorerPolicyPath -Name "ShowFrequent" -Value 1 -Type "DWord" -Force

--- a/includes/disabled/apply-user-customizations.ps1
+++ b/includes/disabled/apply-user-customizations.ps1
@@ -27,7 +27,7 @@ Write-Host "Privileges: $(if($IsAdmin){'Administrator'}else{'Standard User'})" -
 
 # List of validated user-level scripts
 $userScripts = @(
-    @{ Script = 'Hide-Recently-Shortcuts.ps1';       Description = 'Hide recently used shortcuts' },
+    @{ Script = 'Show-Recently-Shortcuts.ps1';       Description = 'Show recently used shortcuts' },
     @{ Script = 'Hide-People-Icon-Taskbar.ps1';      Description = 'Hide People icon from taskbar' },
     @{ Script = 'Hide-Widgets-Icon.ps1';             Description = 'Hide Widgets icon from taskbar' },
     @{ Script = 'Hide-User-Folder-From-Desktop.ps1'; Description = 'Hide User Folder icon from desktop' },


### PR DESCRIPTION
## Summary
- Ensure Explorer policy allows recent and frequent shortcuts by setting `ShowRecent` and `ShowFrequent` to `1`
- Reference the new `Show-Recently-Shortcuts.ps1` script in user customization list

## Testing
- `pwsh -Version` *(command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_6894ab00f92c8332b647a654bdde63f7