### PR TITLE
Enable Num Lock via policy and user hive iteration

### DIFF
--- a/HKCU-to-HKLM-Migration.md
+++ b/HKCU-to-HKLM-Migration.md
@@ -57,3 +57,11 @@ accounts.
 - **New:** `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer\SearchBoxTaskbarMode = 0`
 - **Impact:** ensures the taskbar search box stays hidden system-wide.
 - **Rollback:** delete the HKLM policy value or set it to `1` or `2` to restore the search icon or box.
+
+## Enable-NumLock.ps1
+- **Old:** `HKCU:\Control Panel\Keyboard\InitialKeyboardIndicators = 2` and `HKEY_USERS\.DEFAULT\Control Panel\Keyboard\InitialKeyboardIndicators = 2`
+- **New:** `HKLM:\SOFTWARE\Policies\Microsoft\Control Panel\Keyboard\InitialKeyboardIndicators = 2` when the administrative template is present. Otherwise, the value is set across all loaded user hives.
+- **Safe because:** the policy key is part of Windows administrative templates and enforces consistent behaviour.
+- **Impact:** Num Lock starts enabled for every user account without per-user overrides once policy enforcement is available.
+- **Rollback:** remove the HKLM policy value and reset individual user hive settings as needed.
+

--- a/includes/Enable-NumLock.ps1
+++ b/includes/Enable-NumLock.ps1
@@ -1,3 +1,19 @@
 # Enable Num Lock by default for all users
-Set-RegistryValue -Path "HKCU:\Control Panel\Keyboard" -Name "InitialKeyboardIndicators" -Value "2" -Type "String" -Force
-Set-RegistryValue -Path "Registry::HKEY_USERS\.DEFAULT\Control Panel\Keyboard" -Name "InitialKeyboardIndicators" -Value "2" -Type "String" -Force
+$initialValue = '2'
+$policyPath   = 'HKLM:\SOFTWARE\Policies\Microsoft\Control Panel\Keyboard'
+
+if (Test-Path $policyPath) {
+    # Enforce via policy and remove per-user overrides
+    Set-RegistryValue -Path $policyPath -Name 'InitialKeyboardIndicators' -Value $initialValue -Type 'String' -Force
+
+    Get-ChildItem Registry::HKEY_USERS | Where-Object { $_.PSChildName -notmatch '_Classes$' } | ForEach-Object {
+        $path = "Registry::HKEY_USERS\$($_.PSChildName)\Control Panel\Keyboard"
+        Remove-RegistryValue -Path $path -Name 'InitialKeyboardIndicators'
+    }
+} else {
+    # Apply to all loaded user hives under HKEY_USERS
+    Get-ChildItem Registry::HKEY_USERS | Where-Object { $_.PSChildName -notmatch '_Classes$' } | ForEach-Object {
+        $path = "Registry::HKEY_USERS\$($_.PSChildName)\Control Panel\Keyboard"
+        Set-RegistryValue -Path $path -Name 'InitialKeyboardIndicators' -Value $initialValue -Type 'String' -Force
+    }
+}


### PR DESCRIPTION
## Summary
- Enforce Num Lock through `HKLM` policy when the administrative template is available, removing per-user overrides
- Fall back to updating Num Lock for all loaded user hives when the policy path is absent
- Document the conditional migration from `HKCU` to `HKLM` for the Num Lock setting

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894ab03aa448332a3ce3f89dc0527bf