### PR TITLE
Use policy path for Control Panel icon view

### DIFF
--- a/includes/Set-Control-Panel-View-to-Small-Icons.ps1
+++ b/includes/Set-Control-Panel-View-to-Small-Icons.ps1
@@ -1,3 +1,9 @@
 # Set Control Panel view to Small icons (Classic)
-Set-RegistryValue -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\ControlPanel" -Name "StartupPage" -Value 1 -Type "DWord"
-Set-RegistryValue -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\ControlPanel" -Name "AllItemsIconView" -Value 1 -Type "DWord"
+$policyPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\ControlPanel"
+
+if (-not (Test-Path $policyPath)) {
+    New-Item -Path $policyPath -Force | Out-Null
+}
+
+Set-RegistryValue -Path $policyPath -Name "StartupPage" -Value 1 -Type "DWord"
+Set-RegistryValue -Path $policyPath -Name "AllItemsIconView" -Value 1 -Type "DWord"


### PR DESCRIPTION
## Summary
- set Control Panel display options under HKLM policy key
- avoid HKCU writes to prevent user-level divergence

## Testing
- `pwsh -NoLogo -c "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894ab0998848332b7578bf566437608