### PR TITLE
Show all tray icons via policy

### DIFF
--- a/includes/Hide-All-Tray-Icons.ps1
+++ b/includes/Hide-All-Tray-Icons.ps1
@@ -1,2 +1,0 @@
-# Hide all tray icons
-Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" -Name "EnableAutoTray" -Value 1 -Type "DWord" -Force

--- a/includes/Show-All-Tray-Icons.ps1
+++ b/includes/Show-All-Tray-Icons.ps1
@@ -1,0 +1,2 @@
+# Show all tray icons
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "EnableAutoTray" -Value 0 -Type "DWord" -Force

--- a/includes/disabled/Show-All-Tray-Icons.ps1
+++ b/includes/disabled/Show-All-Tray-Icons.ps1
@@ -1,2 +1,0 @@
-# Show all tray icons
-Set-RegistryValue -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" -Name "EnableAutoTray" -Value 0 -Type "DWord" -Force


### PR DESCRIPTION
## Summary
- enable notification area auto-tray via HKLM policy, showing all tray icons
- remove per-user tray icon customization scripts

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894abca378c8332900634ba6a77f93c