### PR TITLE
Enforce system-wide Autorun policy via HKLM

### DIFF
--- a/HKCU-to-HKLM-Migration.md
+++ b/HKCU-to-HKLM-Migration.md
@@ -57,3 +57,9 @@ accounts.
 - **New:** `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer\SearchBoxTaskbarMode = 0`
 - **Impact:** ensures the taskbar search box stays hidden system-wide.
 - **Rollback:** delete the HKLM policy value or set it to `1` or `2` to restore the search icon or box.
+
+## Disable-Autorun.ps1
+- **Old:** `HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoDriveTypeAutoRun = 255`
+- **New:** `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoDriveTypeAutoRun = 255`
+- **Impact:** disables Autorun for all drives across every user account.
+- **Rollback:** re-create the HKCU value or adjust the HKLM setting to re-enable Autorun.

--- a/includes/disabled/Disable-Autorun.ps1
+++ b/includes/disabled/Disable-Autorun.ps1
@@ -3,3 +3,6 @@ If (!(Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explor
 	New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" | Out-Null
 }
 Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoDriveTypeAutoRun" -Type DWord -Value 255
+if (Test-Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer") {
+    Remove-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "NoDriveTypeAutoRun" -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
- Set `NoDriveTypeAutoRun` to 255 under `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer` and remove any per-user override from `HKCU`
- Document migration from HKCU to HKLM for the Autorun policy

## Testing
- `pwsh -v` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y powershell` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894abc8a67c83328b3f09c3200bdb3f