### PR TITLE
Fix SID variable interpolation in registry backup

### DIFF
--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -188,9 +188,9 @@ foreach ($hive in $userHives) {
             throw "Registry export for HKU\\$sid failed"
         }
     } catch {
-        Write-Warning "Failed to backup registry hive HKU\\$sid: $_"
+        Write-Warning "Failed to backup registry hive HKU\\${sid}: $_"
         $ScriptSuccess = $false
-        $ErrorMessages += "Registry backup HKU\\$sid: $_"
+        $ErrorMessages += "Registry backup HKU\\${sid}: $_"
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent PowerShell from treating `: $_` as part of SID variable name during registry backup warnings
- correctly log SID in registry backup warnings and errors

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894c5599f5c8332b47687af61e8c175