### PR TITLE
Add Harden System Security automation and onboarding bootstrap

### DIFF
--- a/Ensure-Apps.ps1
+++ b/Ensure-Apps.ps1
@@ -1,0 +1,201 @@
+# Ensure-Apps.ps1
+#
+# SuperOps-friendly bootstrap. Run as SYSTEM. Idempotent.
+#
+# - Ensures winget (App Installer MSIX) is provisioned for all users.
+# - Installs machine-scope winget apps directly (PowerShell 7, Chrome, Drive).
+# - Registers a per-user scheduled task that installs msstore / per-user apps
+#   (Harden System Security) at logon and daily, in the user's context where
+#   `winget --source msstore` actually works.
+# - Writes status flags under HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps for a
+#   companion Verify-Apps.ps1 to alert on.
+#
+# Re-running is safe: every action checks state first and no-ops when done.
+
+[CmdletBinding()]
+param(
+    [string] $TaskPath = '\CustomizeWindowsSetup\',
+    [string] $TaskName = 'Install-UserApps'
+)
+
+$ErrorActionPreference = 'Continue'  # never block the rest of the script
+$StateRoot = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps'
+$LogDir    = 'C:\Temp'
+$LogFile   = Join-Path $LogDir 'Ensure-Apps.log'
+
+# --- Machine-scope apps: installed now, as SYSTEM, via winget --------------
+$MachineApps = @(
+    @{ Key='PowerShell7';  WingetId='Microsoft.PowerShell';  Detect={ Test-Path 'C:\Program Files\PowerShell\7\pwsh.exe' } },
+    @{ Key='Chrome';       WingetId='Google.Chrome';         Detect={ Test-Path 'C:\Program Files\Google\Chrome\Application\chrome.exe' } },
+    @{ Key='GoogleDrive';  WingetId='Google.GoogleDrive';    Detect={ Test-Path 'C:\Program Files\Google\Drive File Stream\launch.bat' } }
+)
+
+# --- User-scope apps: installed by the scheduled task at user logon --------
+$UserApps = @(
+    @{ Key='HardenSystemSecurity'; WingetId='9p7ggfl7dx57'; Source='msstore'; DetectAppx='VioletHansen.HardenSystemSecurity' }
+)
+
+# --- Helpers ---------------------------------------------------------------
+function Write-AppLog {
+    param([string]$Message)
+    if (-not (Test-Path $LogDir)) { New-Item -Path $LogDir -ItemType Directory -Force | Out-Null }
+    Add-Content -Path $LogFile -Value "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $Message"
+}
+
+function Set-AppState {
+    param([string]$Key, [string]$Name, $Value, [string]$Type = 'String')
+    $path = Join-Path $StateRoot $Key
+    if (-not (Test-Path $path)) { New-Item -Path $path -Force | Out-Null }
+    New-ItemProperty -Path $path -Name $Name -Value $Value -PropertyType $Type -Force | Out-Null
+}
+
+function Test-IsAdmin {
+    $cur = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+    $cur.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-IsAdmin)) {
+    throw 'Ensure-Apps.ps1 must run as Administrator or SYSTEM.'
+}
+
+# --- Step 1: ensure winget (App Installer) is present for all users --------
+function Ensure-Winget {
+    if (Get-Command winget.exe -ErrorAction SilentlyContinue) {
+        Write-AppLog 'winget already present.'
+        Set-AppState -Key 'Winget' -Name 'Installed' -Value 1 -Type 'DWord'
+        return
+    }
+    # Provisioning the MSIX bundle works under SYSTEM (unlike `winget install`).
+    # If App Installer is missing, you typically need to download the bundle —
+    # SuperOps users usually keep one cached. We try Get-AppxPackage first in
+    # case it's installed but not on SYSTEM's PATH.
+    $appx = Get-AppxPackage -AllUsers -Name 'Microsoft.DesktopAppInstaller' -ErrorAction SilentlyContinue
+    if ($appx) {
+        Write-AppLog "App Installer present (Appx) v$($appx.Version) but not on PATH for SYSTEM. Will be picked up at user logon."
+        Set-AppState -Key 'Winget' -Name 'Installed' -Value 1 -Type 'DWord'
+        return
+    }
+    Write-AppLog 'WARNING: winget / App Installer not present. Push your existing Install/Upgrade Winget script first, or pre-provision Microsoft.DesktopAppInstaller MSIX.'
+    Set-AppState -Key 'Winget' -Name 'Installed' -Value 0 -Type 'DWord'
+}
+
+# --- Step 2: install machine-scope apps directly ---------------------------
+function Install-MachineApp {
+    param($App)
+    if (& $App.Detect) {
+        Write-AppLog "$($App.Key) already installed; skipping."
+        Set-AppState -Key $App.Key -Name 'Installed' -Value 1 -Type 'DWord'
+        return
+    }
+    if (-not (Get-Command winget.exe -ErrorAction SilentlyContinue)) {
+        Write-AppLog "$($App.Key) install skipped: winget not on PATH for SYSTEM."
+        Set-AppState -Key $App.Key -Name 'Installed' -Value 0 -Type 'DWord'
+        return
+    }
+    Write-AppLog "Installing $($App.Key) ($($App.WingetId)) machine-scope..."
+    & winget.exe install --id $App.WingetId --exact --source winget --scope machine `
+        --accept-package-agreements --accept-source-agreements --silent *>> $LogFile
+    $code = $LASTEXITCODE
+    $ok   = (& $App.Detect)
+    Set-AppState -Key $App.Key -Name 'Installed'      -Value ([int]$ok)  -Type 'DWord'
+    Set-AppState -Key $App.Key -Name 'LastInstallExit' -Value $code      -Type 'DWord'
+    Set-AppState -Key $App.Key -Name 'LastAttemptUtc'  -Value (Get-Date).ToUniversalTime().ToString('o') -Type 'String'
+    Write-AppLog "$($App.Key) winget exit=$code, detected=$ok."
+}
+
+# --- Step 3: register per-user logon+daily task for user-scope apps --------
+function Register-UserAppsTask {
+    # Build a payload that loops over the user-scope app list with retries.
+    $items = $UserApps | ForEach-Object {
+        $detect = if ($_.DetectAppx) { "Get-AppxPackage -Name '$($_.DetectAppx)' -ErrorAction SilentlyContinue" } else { '$null' }
+        "@{ Key='$($_.Key)'; WingetId='$($_.WingetId)'; Source='$($_.Source)'; Detect={ $detect } }"
+    }
+    $itemBlock = '@(' + ($items -join ', ') + ')'
+
+    $payload = @"
+`$ErrorActionPreference = 'Continue'
+`$log = 'C:\Temp\Ensure-Apps.log'
+`$stateRoot = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps'
+function Log(`$m) { Add-Content -Path `$log -Value "[`$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] [`$env:USERNAME] `$m" }
+function SetState(`$k,`$n,`$v,`$t='String') {
+    `$p = Join-Path `$stateRoot `$k
+    if (-not (Test-Path `$p)) { New-Item -Path `$p -Force | Out-Null }
+    New-ItemProperty -Path `$p -Name `$n -Value `$v -PropertyType `$t -Force | Out-Null
+}
+
+`$apps = $itemBlock
+foreach (`$app in `$apps) {
+    if (& `$app.Detect) {
+        Log "`$(`$app.Key) already installed; skipping."
+        SetState `$app.Key 'Installed' 1 'DWord'
+        continue
+    }
+    if (-not (Get-Command winget.exe -ErrorAction SilentlyContinue)) {
+        Log "`$(`$app.Key): winget not available."
+        SetState `$app.Key 'Installed' 0 'DWord'
+        continue
+    }
+    `$delays = @(0, 60, 300)  # immediate, +1m, +5m
+    foreach (`$d in `$delays) {
+        if (`$d -gt 0) { Start-Sleep -Seconds `$d }
+        Log "`$(`$app.Key): winget install attempt (after `${d}s)..."
+        & winget.exe install --id `$app.WingetId --exact --source `$app.Source ``
+            --accept-package-agreements --accept-source-agreements --silent *>> `$log
+        if (`$LASTEXITCODE -eq 0 -and (& `$app.Detect)) {
+            SetState `$app.Key 'Installed' 1 'DWord'
+            SetState `$app.Key 'LastInstallExit' 0 'DWord'
+            SetState `$app.Key 'LastAttemptUtc' (Get-Date).ToUniversalTime().ToString('o') 'String'
+            Log "`$(`$app.Key): install succeeded."
+            break
+        }
+        SetState `$app.Key 'LastInstallExit' `$LASTEXITCODE 'DWord'
+        SetState `$app.Key 'LastAttemptUtc' (Get-Date).ToUniversalTime().ToString('o') 'String'
+        Log "`$(`$app.Key): attempt failed (exit `$LASTEXITCODE)."
+    }
+}
+"@
+
+    $payloadDir  = Join-Path $env:ProgramData 'CustomizeWindowsSetup'
+    if (-not (Test-Path $payloadDir)) { New-Item -Path $payloadDir -ItemType Directory -Force | Out-Null }
+    $payloadPath = Join-Path $payloadDir 'Install-UserApps.task.ps1'
+    Set-Content -Path $payloadPath -Value $payload -Encoding UTF8 -Force
+
+    $action = New-ScheduledTaskAction `
+        -Execute 'powershell.exe' `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$payloadPath`""
+
+    $logon = New-ScheduledTaskTrigger -AtLogOn
+    $logon.Delay = 'PT2M'
+    $daily = New-ScheduledTaskTrigger -Daily -At 3am
+
+    $principal = New-ScheduledTaskPrincipal -GroupId 'S-1-5-32-545' -RunLevel Limited
+
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable -MultipleInstances IgnoreNew `
+        -ExecutionTimeLimit (New-TimeSpan -Hours 1)
+
+    $existing = Get-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName -ErrorAction SilentlyContinue
+    if ($existing) {
+        Unregister-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName -Confirm:$false
+    }
+    Register-ScheduledTask `
+        -TaskPath $TaskPath -TaskName $TaskName `
+        -Action $action -Trigger @($logon, $daily) `
+        -Principal $principal -Settings $settings `
+        -Description 'CustomizeWindowsSetup: installs per-user MS Store / msstore-source apps for the logged-in user. Idempotent. Logon + daily 03:00.' | Out-Null
+
+    Write-AppLog "Scheduled task registered: $TaskPath$TaskName (payload: $payloadPath)"
+    Set-AppState -Key 'UserAppsTask' -Name 'Registered'  -Value 1                            -Type 'DWord'
+    Set-AppState -Key 'UserAppsTask' -Name 'PayloadPath' -Value $payloadPath                 -Type 'String'
+    Set-AppState -Key 'UserAppsTask' -Name 'RegisteredUtc' -Value (Get-Date).ToUniversalTime().ToString('o') -Type 'String'
+}
+
+# --- Run -------------------------------------------------------------------
+Write-AppLog '--- Ensure-Apps.ps1 starting ---'
+Ensure-Winget
+foreach ($app in $MachineApps) { Install-MachineApp -App $app }
+Register-UserAppsTask
+Set-AppState -Key 'Bootstrap' -Name 'LastRunUtc' -Value (Get-Date).ToUniversalTime().ToString('o') -Type 'String'
+Write-AppLog '--- Ensure-Apps.ps1 finished ---'
+Write-Host '[SUCCESS] Ensure-Apps complete. See HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps for status.' -ForegroundColor Green

--- a/Verify-Apps.ps1
+++ b/Verify-Apps.ps1
@@ -1,0 +1,41 @@
+# Verify-Apps.ps1
+#
+# SuperOps monitor companion to Ensure-Apps.ps1.
+# Reads HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps status flags AND re-checks
+# each app's actual presence. Prints a one-line status per app and exits
+# non-zero if anything is missing — schedule this in SuperOps to get alerts
+# when an endpoint drifts.
+
+$ErrorActionPreference = 'Continue'
+
+$Checks = @(
+    @{ Key='Winget';               Detect={ [bool](Get-Command winget.exe -ErrorAction SilentlyContinue) -or [bool](Get-AppxPackage -AllUsers -Name 'Microsoft.DesktopAppInstaller' -ErrorAction SilentlyContinue) } },
+    @{ Key='PowerShell7';          Detect={ Test-Path 'C:\Program Files\PowerShell\7\pwsh.exe' } },
+    @{ Key='Chrome';               Detect={ Test-Path 'C:\Program Files\Google\Chrome\Application\chrome.exe' } },
+    @{ Key='GoogleDrive';          Detect={ Test-Path 'C:\Program Files\Google\Drive File Stream\launch.bat' } },
+    @{ Key='HardenSystemSecurity'; Detect={ [bool](Get-AppxPackage -AllUsers -Name 'VioletHansen.HardenSystemSecurity' -ErrorAction SilentlyContinue) } }
+)
+
+$bad = 0
+foreach ($c in $Checks) {
+    $present = [bool](& $c.Detect)
+    $status  = if ($present) { 'OK     ' } else { 'MISSING' }
+    Write-Host "$status $($c.Key)"
+    if (-not $present) { $bad++ }
+}
+
+# Bonus: surface HSS report state from AA-Apply-HardenSystemSecurity.ps1.
+$hssKey = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
+if (Test-Path $hssKey) {
+    $applied = (Get-ItemProperty -Path $hssKey -ErrorAction SilentlyContinue).LastAppliedUtc
+    Write-Host "INFO    HSS report last applied: $applied"
+} else {
+    Write-Host 'INFO    HSS report has never been applied.'
+}
+
+if ($bad -gt 0) {
+    Write-Host "[FAIL] $bad item(s) missing." -ForegroundColor Red
+    exit 1
+}
+Write-Host '[OK] All apps present.' -ForegroundColor Green
+exit 0

--- a/includes/AA-Apply-HardenSystemSecurity.ps1
+++ b/includes/AA-Apply-HardenSystemSecurity.ps1
@@ -1,0 +1,119 @@
+# Applies a Harden System Security report (HotCakeX/Harden-Windows-Security)
+# as the very first customization step. Designed to run on a schedule.
+#
+# Documented mechanism (see HSS wiki):
+#   HSS.exe --cli ImportReport --in=<file> --mode=full
+#   "Import and apply a previously exported system state report. Elevation
+#    is required. full -> apply all measures marked applied AND remove all
+#    measures marked not applied."
+#
+# Execution context:
+#   - Safe to run as SYSTEM (SuperOps default) OR as an interactive admin.
+#   - HSS.exe is a Microsoft Store app. PATH/AppExecutionAlias does NOT resolve
+#     under SYSTEM, so we locate HSS.exe via Get-AppxPackage -AllUsers.
+#   - Installation: winget `--source msstore` is unreliable under SYSTEM.
+#     This script will only attempt winget when run interactively. Under SYSTEM
+#     the app must be pre-installed (Store, or one-off user-context winget).
+#
+# Re-run policy:
+#   SHA-256 of the report is recorded at
+#     HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity\ReportHash
+#   Same hash -> skip. Different/missing -> apply and update. To force a
+#   re-apply on the next run, delete that registry value.
+
+$ReportFile = Join-Path $PSScriptRoot 'Harden-System-Security.report.json'
+$StateKey   = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
+$StoreId    = '9p7ggfl7dx57'
+$PkgFamily  = 'VioletHansen.HardenSystemSecurity_ea7andspwdn10'
+$PkgName    = 'VioletHansen.HardenSystemSecurity'
+
+if (-not (Test-Path -LiteralPath $ReportFile)) {
+    Write-Log "ERROR: Harden System Security report not found at $ReportFile"
+    Write-Host "[ERROR] Report file missing: $ReportFile" -ForegroundColor Red
+    return
+}
+
+function Test-IsSystem {
+    ([Security.Principal.WindowsIdentity]::GetCurrent()).User.Value -eq 'S-1-5-18'
+}
+
+function Resolve-HssExe {
+    # Look up the installed Appx package across all users, then point at HSS.exe
+    # inside its InstallLocation. Works whether we're SYSTEM or an admin user.
+    $pkg = Get-AppxPackage -AllUsers -Name $PkgName -ErrorAction SilentlyContinue |
+        Sort-Object -Property Version -Descending |
+        Select-Object -First 1
+    if (-not $pkg) { return $null }
+    $exe = Join-Path $pkg.InstallLocation 'HSS.exe'
+    if (Test-Path -LiteralPath $exe) { return $exe }
+    return $null
+}
+
+function Install-Hss {
+    if (Test-IsSystem) {
+        throw @"
+Harden System Security is not installed and this script is running as SYSTEM.
+Microsoft Store installs via winget are unreliable under SYSTEM. Install once
+in an interactive admin context with:
+
+    winget install --id $StoreId --exact --source msstore ``
+        --accept-package-agreements --accept-source-agreements
+
+or via the Store: https://apps.microsoft.com/detail/$StoreId
+Then re-run this script.
+"@
+    }
+    Write-Host '[INFO] Installing Harden System Security from Microsoft Store...' -ForegroundColor Cyan
+    if (-not (Get-Command 'winget.exe' -ErrorAction SilentlyContinue)) {
+        throw 'winget is not available. Install "App Installer" from the Microsoft Store and re-run.'
+    }
+    & winget install --id $StoreId --exact `
+        --accept-package-agreements --accept-source-agreements `
+        --source msstore | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "winget install failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Invoke-Hss {
+    param([Parameter(Mandatory)][string]$Exe, [Parameter(Mandatory)][string[]]$Arguments)
+    Write-Host "[INFO] $Exe $($Arguments -join ' ')" -ForegroundColor DarkCyan
+    & $Exe @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "HSS.exe exited with code $LASTEXITCODE."
+    }
+}
+
+try {
+    $currentHash = (Get-FileHash -LiteralPath $ReportFile -Algorithm SHA256).Hash
+    $storedHash  = $null
+    if (Test-Path -LiteralPath $StateKey) {
+        $storedHash = (Get-ItemProperty -Path $StateKey -Name 'ReportHash' -ErrorAction SilentlyContinue).ReportHash
+    }
+
+    if ($storedHash -eq $currentHash) {
+        Write-Host "[INFO] Harden System Security report unchanged (hash $($currentHash.Substring(0,12))...); skipping." -ForegroundColor DarkGray
+        return
+    }
+
+    $hss = Resolve-HssExe
+    if (-not $hss) {
+        Install-Hss
+        $hss = Resolve-HssExe
+        if (-not $hss) { throw 'HSS.exe still not found after install attempt.' }
+    }
+    Write-Host "[INFO] Using HSS.exe at: $hss" -ForegroundColor DarkGray
+
+    Write-Host "[INFO] Importing report '$ReportFile' (mode=full)..." -ForegroundColor Cyan
+    Invoke-Hss -Exe $hss -Arguments @('--cli', 'ImportReport', "--in=$ReportFile", '--mode=full')
+    Write-Log "Harden System Security: imported report from $ReportFile in mode=full (hash $currentHash)."
+
+    Set-RegistryValue -Path $StateKey -Name 'ReportHash'     -Value $currentHash                               -Type 'String' -Force
+    Set-RegistryValue -Path $StateKey -Name 'ReportPath'     -Value $ReportFile                                -Type 'String' -Force
+    Set-RegistryValue -Path $StateKey -Name 'LastAppliedUtc' -Value (Get-Date).ToUniversalTime().ToString('o') -Type 'String' -Force
+
+    Write-Host '[SUCCESS] Harden System Security report applied.' -ForegroundColor Green
+} catch {
+    Write-Log "ERROR: Harden System Security apply failed - $_"
+    Write-Host "[ERROR] Harden System Security apply failed: $_" -ForegroundColor Red
+}

--- a/includes/Harden-System-Security.report.json
+++ b/includes/Harden-System-Security.report.json
@@ -1,0 +1,11705 @@
+{
+  "Time": "2026-04-11T17:48:20.6158744+01:00",
+  "MachineName": "NASSIR-YOGA-26",
+  "UserName": "Nassir Fazal",
+  "AppVersion": "1.0.49.0",
+  "Total": 1129,
+  "Compliant": 986,
+  "NonCompliant": 143,
+  "MicrosoftSecurityBaseline": {
+    "Count": 421,
+    "Items": [
+      {
+        "ID": "AuditPolicy|0cce923f-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Credential Validation",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9237-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Security Group Management",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9235-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit User Account Management",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9248-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit PNP Activity",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce922b-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Process Creation",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9217-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Account Lockout",
+        "Is Compliant": true,
+        "Current Value": "Failure",
+        "Expected Value": "Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9249-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Group Membership",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9215-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Logon",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce921c-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Other Logon/Logoff Events",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce921b-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Special Logon",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9244-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Detailed File Share",
+        "Is Compliant": true,
+        "Current Value": "Failure",
+        "Expected Value": "Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9224-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit File Share",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9227-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Other Object Access Events",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9245-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Removable Storage",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce922f-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Audit Policy Change",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9230-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Authentication Policy Change",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9232-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit MPSSVC Rule-Level Policy Change",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9234-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Other Policy Change Events",
+        "Is Compliant": true,
+        "Current Value": "Failure",
+        "Expected Value": "Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9228-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Sensitive Privilege Use",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9214-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Other System Events",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9210-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Security State Change",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9211-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit Security System Extension",
+        "Is Compliant": true,
+        "Current Value": "Success",
+        "Expected Value": "Success",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "AuditPolicy|0cce9212-69ae-11d9-bed3-505054503030",
+        "Friendly Name": "Audit System Integrity",
+        "Is Compliant": true,
+        "Current Value": "Success and Failure",
+        "Expected Value": "Success and Failure",
+        "Source": "AuditPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\WcmSvc\\wifinetworkmanager\\config|AutoConnectAllowedOEM",
+        "Friendly Name": "Software\\Microsoft\\WcmSvc\\wifinetworkmanager\\config\\AutoConnectAllowedOEM",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\CredUI|EnumerateAdministrators",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\CredUI\\EnumerateAdministrators",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer|NoDriveTypeAutoRun",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\NoDriveTypeAutoRun",
+        "Is Compliant": true,
+        "Current Value": "255",
+        "Expected Value": "255",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer|NoWebServices",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\NoWebServices",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer|NoAutorun",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\NoAutorun",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\LAPS|BackupDirectory",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\LAPS\\BackupDirectory",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\LAPS|ADPasswordEncryptionEnabled",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\LAPS\\ADPasswordEncryptionEnabled",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\LAPS|ADBackupDSRMPassword",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\LAPS\\ADBackupDSRMPassword",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|MSAOptional",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\MSAOptional",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|DisableAutomaticRestartSignOn",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\DisableAutomaticRestartSignOn",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|LocalAccountTokenFilterPolicy",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\LocalAccountTokenFilterPolicy",
+        "Is Compliant": false,
+        "Current Value": "Not Found",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|EnableMPR",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableMPR",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Audit|ProcessCreationIncludeCmdLine_Enabled",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Audit\\ProcessCreationIncludeCmdLine_Enabled",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\CredSSP\\Parameters|AllowEncryptionOracle",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\CredSSP\\Parameters\\AllowEncryptionOracle",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters|PKINITHashAlgorithmConfigurationEnabled",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters\\PKINITHashAlgorithmConfigurationEnabled",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters|PKINITSHA1",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters\\PKINITSHA1",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters|PKINITSHA256",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters\\PKINITSHA256",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters|PKINITSHA384",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters\\PKINITSHA384",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters|PKINITSHA512",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\KDC\\Parameters\\PKINITSHA512",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters|PKInitHashAlgorithmConfigurationEnabled",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters\\PKInitHashAlgorithmConfigurationEnabled",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters|PKInitSHA1",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters\\PKInitSHA1",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters|PKInitSHA256",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters\\PKInitSHA256",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters|PKInitSHA384",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters\\PKInitSHA384",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters|PKInitSHA512",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Kerberos\\Parameters\\PKInitSHA512",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Biometrics\\FacialFeatures|EnhancedAntiSpoofing",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Biometrics\\FacialFeatures\\EnhancedAntiSpoofing",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Feeds|DisableEnclosureDownload",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Feeds\\DisableEnclosureDownload",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Power\\PowerSettings\\0e796bdb-100d-47d6-a2d5-f7d2daa51f51|DCSettingIndex",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Power\\PowerSettings\\0e796bdb-100d-47d6-a2d5-f7d2daa51f51\\DCSettingIndex",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Power\\PowerSettings\\0e796bdb-100d-47d6-a2d5-f7d2daa51f51|ACSettingIndex",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Power\\PowerSettings\\0e796bdb-100d-47d6-a2d5-f7d2daa51f51\\ACSettingIndex",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\AppPrivacy|LetAppsActivateWithVoiceAboveLock",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\AppPrivacy\\LetAppsActivateWithVoiceAboveLock",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Bowser|EnableMailslots",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Bowser\\EnableMailslots",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CloudContent|DisableWindowsConsumerFeatures",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CloudContent\\DisableWindowsConsumerFeatures",
+        "Is Compliant": false,
+        "Current Value": "Not Found",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CredentialsDelegation|AllowProtectedCreds",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CredentialsDelegation\\AllowProtectedCreds",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\EventLog\\Application|MaxSize",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\EventLog\\Application\\MaxSize",
+        "Is Compliant": true,
+        "Current Value": "32768",
+        "Expected Value": "32768",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\EventLog\\Security|MaxSize",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\EventLog\\Security\\MaxSize",
+        "Is Compliant": true,
+        "Current Value": "196608",
+        "Expected Value": "196608",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\EventLog\\System|MaxSize",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\EventLog\\System\\MaxSize",
+        "Is Compliant": true,
+        "Current Value": "32768",
+        "Expected Value": "32768",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Explorer|NoAutoplayfornonVolume",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Explorer\\NoAutoplayfornonVolume",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Explorer|DisableMotWOnInsecurePathCopy",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Explorer\\DisableMotWOnInsecurePathCopy",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\GameDVR|AllowGameDVR",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\GameDVR\\AllowGameDVR",
+        "Is Compliant": false,
+        "Current Value": "Not Found",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Installer|AlwaysInstallElevated",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Installer\\AlwaysInstallElevated",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Installer|EnableUserControl",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Installer\\EnableUserControl",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Kernel DMA Protection|DeviceEnumerationPolicy",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Kernel DMA Protection\\DeviceEnumerationPolicy",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanServer|AuditClientDoesNotSupportEncryption",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanServer\\AuditClientDoesNotSupportEncryption",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanServer|AuditClientDoesNotSupportSigning",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanServer\\AuditClientDoesNotSupportSigning",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanServer|AuditInsecureGuestLogon",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanServer\\AuditInsecureGuestLogon",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanServer|EnableAuthRateLimiter",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanServer\\EnableAuthRateLimiter",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanServer|MaxSmb2Dialect",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanServer\\MaxSmb2Dialect",
+        "Is Compliant": true,
+        "Current Value": "785",
+        "Expected Value": "785",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanServer|MinSmb2Dialect",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanServer\\MinSmb2Dialect",
+        "Is Compliant": false,
+        "Current Value": "785",
+        "Expected Value": "768",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanServer|InvalidAuthenticationDelayTimeInMs",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanServer\\InvalidAuthenticationDelayTimeInMs",
+        "Is Compliant": true,
+        "Current Value": "2000",
+        "Expected Value": "2000",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation|AllowInsecureGuestAuth",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation\\AllowInsecureGuestAuth",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation|AuditInsecureGuestLogon",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation\\AuditInsecureGuestLogon",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation|AuditServerDoesNotSupportEncryption",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation\\AuditServerDoesNotSupportEncryption",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation|AuditServerDoesNotSupportSigning",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation\\AuditServerDoesNotSupportSigning",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation|MaxSmb2Dialect",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation\\MaxSmb2Dialect",
+        "Is Compliant": true,
+        "Current Value": "785",
+        "Expected Value": "785",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation|MinSmb2Dialect",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation\\MinSmb2Dialect",
+        "Is Compliant": false,
+        "Current Value": "785",
+        "Expected Value": "768",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation|RequireEncryption",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\LanmanWorkstation\\RequireEncryption",
+        "Is Compliant": false,
+        "Current Value": "1",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Network Connections|NC_ShowSharedAccessUI",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Network Connections\\NC_ShowSharedAccessUI",
+        "Is Compliant": false,
+        "Current Value": "Not Found",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\NetworkProvider|EnableMailslots",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\NetworkProvider\\EnableMailslots",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths|\\\\*\\SYSVOL",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths\\\\\\*\\SYSVOL",
+        "Is Compliant": true,
+        "Current Value": "\"RequireMutualAuthentication=1,RequireIntegrity=1\"",
+        "Expected Value": "RequireMutualAuthentication=1,RequireIntegrity=1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths|\\\\*\\NETLOGON",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\NetworkProvider\\HardenedPaths\\\\\\*\\NETLOGON",
+        "Is Compliant": true,
+        "Current Value": "\"RequireMutualAuthentication=1,RequireIntegrity=1\"",
+        "Expected Value": "RequireMutualAuthentication=1,RequireIntegrity=1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Personalization|NoLockScreenCamera",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Personalization\\NoLockScreenCamera",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Personalization|NoLockScreenSlideshow",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Personalization\\NoLockScreenSlideshow",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging|EnableScriptBlockLogging",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging\\EnableScriptBlockLogging",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging|**del.EnableScriptBlockInvocationLogging",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging\\**del.EnableScriptBlockInvocationLogging",
+        "Is Compliant": true,
+        "Current Value": "\" \"",
+        "Expected Value": " ",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Sudo|Enabled",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Sudo\\Enabled",
+        "Is Compliant": false,
+        "Current Value": "Not Found",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\System|AllowDomainPINLogon",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\System\\AllowDomainPINLogon",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\System|EnumerateLocalUsers",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\System\\EnumerateLocalUsers",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\System|EnableSmartScreen",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\System\\EnableSmartScreen",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\System|ShellSmartScreenLevel",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\System\\ShellSmartScreenLevel",
+        "Is Compliant": true,
+        "Current Value": "\"Block\"",
+        "Expected Value": "Block",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\System|AllowCustomSSPsAPs",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\System\\AllowCustomSSPsAPs",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\System|RunAsPPL",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\System\\RunAsPPL",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WcmSvc\\GroupPolicy|fBlockNonDomain",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WcmSvc\\GroupPolicy\\fBlockNonDomain",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\Windows Search|AllowIndexingEncryptedStoresOrItems",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\Windows Search\\AllowIndexingEncryptedStoresOrItems",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WinRM\\Client|AllowDigest",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WinRM\\Client\\AllowDigest",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WinRM\\Client|AllowUnencryptedTraffic",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WinRM\\Client\\AllowUnencryptedTraffic",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WinRM\\Client|AllowBasic",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WinRM\\Client\\AllowBasic",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WinRM\\Service|AllowUnencryptedTraffic",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WinRM\\Service\\AllowUnencryptedTraffic",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WinRM\\Service|DisableRunAs",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WinRM\\Service\\DisableRunAs",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WinRM\\Service|AllowBasic",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WinRM\\Service\\AllowBasic",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WTDS\\Components|NotifyMalicious",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WTDS\\Components\\NotifyMalicious",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WTDS\\Components|NotifyPasswordReuse",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WTDS\\Components\\NotifyPasswordReuse",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WTDS\\Components|NotifyUnsafeApp",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WTDS\\Components\\NotifyUnsafeApp",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\WTDS\\Components|ServiceEnabled",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\WTDS\\Components\\ServiceEnabled",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\DNSClient|EnableMulticast",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\DNSClient\\EnableMulticast",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\DNSClient|EnableNetbios",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\DNSClient\\EnableNetbios",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Printers|DisableWebPnPDownload",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Printers\\DisableWebPnPDownload",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Printers|RedirectionGuardPolicy",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Printers\\RedirectionGuardPolicy",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Printers|CopyFilesPolicy",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Printers\\CopyFilesPolicy",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Printers\\PointAndPrint|RestrictDriverInstallationToAdministrators",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Printers\\PointAndPrint\\RestrictDriverInstallationToAdministrators",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC|RpcUseNamedPipeProtocol",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC\\RpcUseNamedPipeProtocol",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC|RpcAuthentication",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC\\RpcAuthentication",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC|RpcProtocols",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC\\RpcProtocols",
+        "Is Compliant": true,
+        "Current Value": "5",
+        "Expected Value": "5",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC|ForceKerberosForRpc",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC\\ForceKerberosForRpc",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC|RpcTcpPort",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Printers\\RPC\\RpcTcpPort",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Rpc|RestrictRemoteClients",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Rpc\\RestrictRemoteClients",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|**del.fUseMailto",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\**del.fUseMailto",
+        "Is Compliant": true,
+        "Current Value": "\" \"",
+        "Expected Value": " ",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|fAllowToGetHelp",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\fAllowToGetHelp",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|**del.fAllowFullControl",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\**del.fAllowFullControl",
+        "Is Compliant": true,
+        "Current Value": "\" \"",
+        "Expected Value": " ",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|**del.MaxTicketExpiry",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\**del.MaxTicketExpiry",
+        "Is Compliant": true,
+        "Current Value": "\" \"",
+        "Expected Value": " ",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|**del.MaxTicketExpiryUnits",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\**del.MaxTicketExpiryUnits",
+        "Is Compliant": true,
+        "Current Value": "\" \"",
+        "Expected Value": " ",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|MinEncryptionLevel",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\MinEncryptionLevel",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|fPromptForPassword",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\fPromptForPassword",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|fDisableCdm",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\fDisableCdm",
+        "Is Compliant": false,
+        "Current Value": "Not Found",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|DisablePasswordSaving",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\DisablePasswordSaving",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows NT\\Terminal Services|fEncryptRPCTraffic",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\fEncryptRPCTraffic",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall|PolicyVersion",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PolicyVersion",
+        "Is Compliant": false,
+        "Current Value": "545",
+        "Expected Value": "538",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile|DefaultOutboundAction",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\DefaultOutboundAction",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile|DisableNotifications",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\DisableNotifications",
+        "Is Compliant": false,
+        "Current Value": "0",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile|EnableFirewall",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\EnableFirewall",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile|DefaultInboundAction",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\DefaultInboundAction",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\Logging|LogDroppedPackets",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\Logging\\LogDroppedPackets",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\Logging|LogFileSize",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\Logging\\LogFileSize",
+        "Is Compliant": false,
+        "Current Value": "32767",
+        "Expected Value": "16384",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\Logging|LogSuccessfulConnections",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\DomainProfile\\Logging\\LogSuccessfulConnections",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile|EnableFirewall",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\EnableFirewall",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile|DisableNotifications",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\DisableNotifications",
+        "Is Compliant": false,
+        "Current Value": "0",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile|DefaultInboundAction",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\DefaultInboundAction",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile|DefaultOutboundAction",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\DefaultOutboundAction",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\Logging|LogSuccessfulConnections",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\Logging\\LogSuccessfulConnections",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\Logging|LogDroppedPackets",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\Logging\\LogDroppedPackets",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\Logging|LogFileSize",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\Logging\\LogFileSize",
+        "Is Compliant": false,
+        "Current Value": "32767",
+        "Expected Value": "16384",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile|DefaultOutboundAction",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\DefaultOutboundAction",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile|EnableFirewall",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\EnableFirewall",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile|DisableNotifications",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\DisableNotifications",
+        "Is Compliant": false,
+        "Current Value": "0",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile|AllowLocalIPsecPolicyMerge",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\AllowLocalIPsecPolicyMerge",
+        "Is Compliant": false,
+        "Current Value": "1",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile|AllowLocalPolicyMerge",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\AllowLocalPolicyMerge",
+        "Is Compliant": false,
+        "Current Value": "1",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile|DefaultInboundAction",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\DefaultInboundAction",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\Logging|LogFileSize",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\Logging\\LogFileSize",
+        "Is Compliant": false,
+        "Current Value": "32767",
+        "Expected Value": "16384",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\Logging|LogDroppedPackets",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\Logging\\LogDroppedPackets",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\Logging|LogSuccessfulConnections",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\Logging\\LogSuccessfulConnections",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\WindowsInkWorkspace|AllowWindowsInkWorkspace",
+        "Friendly Name": "Software\\Policies\\Microsoft\\WindowsInkWorkspace\\AllowWindowsInkWorkspace",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Control\\Lsa|RunAsPPL",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Control\\Lsa\\RunAsPPL",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Control\\Print|RpcAuthnLevelPrivacyEnabled",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Control\\Print\\RpcAuthnLevelPrivacyEnabled",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Control\\Session Manager\\kernel|DisableExceptionChainValidation",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\kernel\\DisableExceptionChainValidation",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Policies\\EarlyLaunch|DriverLoadPolicy",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Policies\\EarlyLaunch\\DriverLoadPolicy",
+        "Is Compliant": false,
+        "Current Value": "8",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters|SMB1",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters\\SMB1",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Services\\MrxSmb10|Start",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Services\\MrxSmb10\\Start",
+        "Is Compliant": true,
+        "Current Value": "4",
+        "Expected Value": "4",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Services\\Netbt\\Parameters|NoNameReleaseOnDemand",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Services\\Netbt\\Parameters\\NoNameReleaseOnDemand",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Services\\Netbt\\Parameters|NodeType",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Services\\Netbt\\Parameters\\NodeType",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters|EnableICMPRedirect",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\EnableICMPRedirect",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters|DisableIPSourceRouting",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\DisableIPSourceRouting",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters|DisableIPSourceRouting",
+        "Friendly Name": "SYSTEM\\CurrentControlSet\\Services\\Tcpip6\\Parameters\\DisableIPSourceRouting",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Ext|RunThisTimeEnabled",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Ext\\RunThisTimeEnabled",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Ext|VersionCheckEnabled",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Ext\\VersionCheckEnabled",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Download|RunInvalidSignatures",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Download\\RunInvalidSignatures",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Download|CheckExeSignatures",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Download\\CheckExeSignatures",
+        "Is Compliant": true,
+        "Current Value": "\"yes\"",
+        "Expected Value": "yes",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main|Isolation64Bit",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\Isolation64Bit",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main|DisableEPMCompat",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\DisableEPMCompat",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main|Isolation",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\Isolation",
+        "Is Compliant": true,
+        "Current Value": "\"PMEM\"",
+        "Expected Value": "PMEM",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main|DisableInternetExplorerLaunchViaCOM",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\DisableInternetExplorerLaunchViaCOM",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_DISABLE_MK_PROTOCOL|(Reserved)",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_DISABLE_MK_PROTOCOL\\(Reserved)",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_DISABLE_MK_PROTOCOL|iexplore.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_DISABLE_MK_PROTOCOL\\iexplore.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_DISABLE_MK_PROTOCOL|explorer.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_DISABLE_MK_PROTOCOL\\explorer.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_HANDLING|explorer.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_HANDLING\\explorer.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_HANDLING|iexplore.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_HANDLING\\iexplore.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_HANDLING|(Reserved)",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_HANDLING\\(Reserved)",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_SNIFFING|explorer.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_SNIFFING\\explorer.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_SNIFFING|iexplore.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_SNIFFING\\iexplore.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_SNIFFING|(Reserved)",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_MIME_SNIFFING\\(Reserved)",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_ACTIVEXINSTALL|(Reserved)",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_ACTIVEXINSTALL\\(Reserved)",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_ACTIVEXINSTALL|explorer.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_ACTIVEXINSTALL\\explorer.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_ACTIVEXINSTALL|iexplore.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_ACTIVEXINSTALL\\iexplore.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_FILEDOWNLOAD|(Reserved)",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_FILEDOWNLOAD\\(Reserved)",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_FILEDOWNLOAD|iexplore.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_FILEDOWNLOAD\\iexplore.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_FILEDOWNLOAD|explorer.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_RESTRICT_FILEDOWNLOAD\\explorer.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_SECURITYBAND|(Reserved)",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_SECURITYBAND\\(Reserved)",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_SECURITYBAND|iexplore.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_SECURITYBAND\\iexplore.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_SECURITYBAND|explorer.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_SECURITYBAND\\explorer.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_WINDOW_RESTRICTIONS|iexplore.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_WINDOW_RESTRICTIONS\\iexplore.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_WINDOW_RESTRICTIONS|(Reserved)",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_WINDOW_RESTRICTIONS\\(Reserved)",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_WINDOW_RESTRICTIONS|explorer.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_WINDOW_RESTRICTIONS\\explorer.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_ZONE_ELEVATION|(Reserved)",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_ZONE_ELEVATION\\(Reserved)",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_ZONE_ELEVATION|explorer.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_ZONE_ELEVATION\\explorer.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_ZONE_ELEVATION|iexplore.exe",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_ZONE_ELEVATION\\iexplore.exe",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\PhishingFilter|PreventOverrideAppRepUnknown",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\PhishingFilter\\PreventOverrideAppRepUnknown",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\PhishingFilter|PreventOverride",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\PhishingFilter\\PreventOverride",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\PhishingFilter|EnabledV9",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\PhishingFilter\\EnabledV9",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Restrictions|NoCrashDetection",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Restrictions\\NoCrashDetection",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Security|DisableSecuritySettingsCheck",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Security\\DisableSecuritySettingsCheck",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Security\\ActiveX|BlockNonAdminActiveXInstall",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Security\\ActiveX\\BlockNonAdminActiveXInstall",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\AxInstaller|OnlyUseAXISForActiveXInstall",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\AxInstaller\\OnlyUseAXISForActiveXInstall",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings|Security_zones_map_edit",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Security_zones_map_edit",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings|Security_options_edit",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Security_options_edit",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings|Security_HKLM_only",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Security_HKLM_only",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings|CertificateRevocation",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\CertificateRevocation",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings|PreventIgnoreCertErrors",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\PreventIgnoreCertErrors",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings|WarnOnBadCertRecving",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\WarnOnBadCertRecving",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings|EnableSSL3Fallback",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\EnableSSL3Fallback",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings|SecureProtocols",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\SecureProtocols",
+        "Is Compliant": true,
+        "Current Value": "2560",
+        "Expected Value": "2560",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\0|1C00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\0\\1C00",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\1|1C00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\1\\1C00",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\2|1C00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\2\\1C00",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\3|2301",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\3\\2301",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\4|2301",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\4\\2301",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\4|1C00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Lockdown_Zones\\4\\1C00",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\ZoneMap|UNCAsIntranet",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\ZoneMap\\UNCAsIntranet",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\0|1C00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\0\\1C00",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\0|270C",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\0\\270C",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\1|270C",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\1\\270C",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\1|1201",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\1\\1201",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\1|1C00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\1\\1C00",
+        "Is Compliant": true,
+        "Current Value": "65536",
+        "Expected Value": "65536",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\2|1C00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\2\\1C00",
+        "Is Compliant": true,
+        "Current Value": "65536",
+        "Expected Value": "65536",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\2|270C",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\2\\270C",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\2|1201",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\2\\1201",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2001",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2001",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2102",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2102",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1802",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1802",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|160A",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\160A",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1201",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1201",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1406",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1406",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1804",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1804",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2200",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2200",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1209",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1209",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1206",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1206",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1809",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1809",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2500",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2500",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2103",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2103",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1606",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1606",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2402",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2402",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2004",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2004",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1C00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1C00",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1001",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1001",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1A00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1A00",
+        "Is Compliant": true,
+        "Current Value": "65536",
+        "Expected Value": "65536",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2708",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2708",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1004",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1004",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|120b",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\120b",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1407",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1407",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1409",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1409",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|270C",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\270C",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1607",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1607",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2709",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2709",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2101",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2101",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|2301",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\2301",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|1806",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\1806",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|120c",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\120c",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3|140C",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\3\\140C",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1608",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1608",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1201",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1201",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1001",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1001",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1607",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1607",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|120b",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\120b",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1809",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1809",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1004",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1004",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1606",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1606",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1407",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1407",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|160A",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\160A",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1406",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1406",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2102",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2102",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2004",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2004",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2200",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2200",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2000",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2000",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1402",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1402",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1803",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1803",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2402",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2402",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1400",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1400",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1A00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1A00",
+        "Is Compliant": true,
+        "Current Value": "196608",
+        "Expected Value": "196608",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2001",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2001",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2500",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2500",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1409",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1409",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1C00",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1C00",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1209",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1209",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|270C",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\270C",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1206",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1206",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2708",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2708",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1802",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1802",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2103",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2103",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2709",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2709",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1405",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1405",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2101",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2101",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|2301",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\2301",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1200",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1200",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1804",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1804",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|1806",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\1806",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|120c",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\120c",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4|140C",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Zones\\4\\140C",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender|PUAProtection",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\PUAProtection",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender|DisableLocalAdminMerge",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\DisableLocalAdminMerge",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender|HideExclusionsFromLocalAdmins",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\HideExclusionsFromLocalAdmins",
+        "Is Compliant": false,
+        "Current Value": "Not Found",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender|DisableRoutinelyTakingAction",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\DisableRoutinelyTakingAction",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Features|PassiveRemediation",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Features\\PassiveRemediation",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\MpEngine|MpCloudBlockLevel",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\MpEngine\\MpCloudBlockLevel",
+        "Is Compliant": false,
+        "Current Value": "6",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\MpEngine|MpBafsExtendedTimeout",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\MpEngine\\MpBafsExtendedTimeout",
+        "Is Compliant": true,
+        "Current Value": "50",
+        "Expected Value": "50",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\NIS|EnableConvertWarnToBlock",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\NIS\\EnableConvertWarnToBlock",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection|DisableIOAVProtection",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIOAVProtection",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection|DisableRealtimeMonitoring",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableRealtimeMonitoring",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection|DisableScriptScanning",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableScriptScanning",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection|DisableBehaviorMonitoring",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableBehaviorMonitoring",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection|RealtimeScanDirection",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\RealtimeScanDirection",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection|DisableOnAccessProtection",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableOnAccessProtection",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection|DisableScanOnRealtimeEnable",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableScanOnRealtimeEnable",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection|OobeEnableRtpAndSigUpdate",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\OobeEnableRtpAndSigUpdate",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Reporting|EnableDynamicSignatureDroppedEventReporting",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Reporting\\EnableDynamicSignatureDroppedEventReporting",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Scan|DisableRemovableDriveScanning",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Scan\\DisableRemovableDriveScanning",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Scan|QuickScanIncludeExclusions",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Scan\\QuickScanIncludeExclusions",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Spynet|SpynetReporting",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Spynet\\SpynetReporting",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Spynet|DisableBlockAtFirstSeen",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Spynet\\DisableBlockAtFirstSeen",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Spynet|SubmitSamplesConsent",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Spynet\\SubmitSamplesConsent",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR|ExploitGuard_ASR_Rules",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\ExploitGuard_ASR_Rules",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84",
+        "Is Compliant": false,
+        "Current Value": "\"6\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|3b576869-a4ec-4529-8536-b80a7769e899",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\3b576869-a4ec-4529-8536-b80a7769e899",
+        "Is Compliant": false,
+        "Current Value": "\"6\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|d4f940ab-401b-4efc-aadc-ad5f3c50688a",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\d4f940ab-401b-4efc-aadc-ad5f3c50688a",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B",
+        "Is Compliant": false,
+        "Current Value": "\"6\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|5beb7efe-fd9a-4556-801d-275e5ffc04cc",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\5beb7efe-fd9a-4556-801d-275e5ffc04cc",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|d3e037e1-3eb8-44c8-a917-57927947596d",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\d3e037e1-3eb8-44c8-a917-57927947596d",
+        "Is Compliant": false,
+        "Current Value": "\"6\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|be9ba2d9-53ea-4cdc-84e5-9b1eeee46550",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\be9ba2d9-53ea-4cdc-84e5-9b1eeee46550",
+        "Is Compliant": false,
+        "Current Value": "\"6\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4",
+        "Is Compliant": false,
+        "Current Value": "\"6\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|26190899-1602-49e8-8b27-eb1d0a1ce869",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\26190899-1602-49e8-8b27-eb1d0a1ce869",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|c1db55ab-c21a-4637-bb3f-a12568109d35",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\c1db55ab-c21a-4637-bb3f-a12568109d35",
+        "Is Compliant": false,
+        "Current Value": "\"6\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|e6db77e5-3df2-4cf1-b95a-636979351e5b",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\e6db77e5-3df2-4cf1-b95a-636979351e5b",
+        "Is Compliant": true,
+        "Current Value": "\"1\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|56a863a9-875e-4185-98a7-b882c64b5ce5",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\56a863a9-875e-4185-98a7-b882c64b5ce5",
+        "Is Compliant": false,
+        "Current Value": "\"6\"",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules|d1e49aac-8f56-4280-b9ba-993a6d77406c",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\ASR\\Rules\\d1e49aac-8f56-4280-b9ba-993a6d77406c",
+        "Is Compliant": false,
+        "Current Value": "\"6\"",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\Network Protection|EnableNetworkProtection",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\Network Protection\\EnableNetworkProtection",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\FVE|UseEnhancedPin",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\FVE\\UseEnhancedPin",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\FVE|RDVDenyCrossOrg",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\FVE\\RDVDenyCrossOrg",
+        "Is Compliant": false,
+        "Current Value": "Not Found",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\FVE|DisableExternalDMAUnderLock",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\FVE\\DisableExternalDMAUnderLock",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Power\\PowerSettings\\abfc2519-3608-4c2a-94ea-171b0ed546ab|DCSettingIndex",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Power\\PowerSettings\\abfc2519-3608-4c2a-94ea-171b0ed546ab\\DCSettingIndex",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Power\\PowerSettings\\abfc2519-3608-4c2a-94ea-171b0ed546ab|ACSettingIndex",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Power\\PowerSettings\\abfc2519-3608-4c2a-94ea-171b0ed546ab\\ACSettingIndex",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceInstall\\Restrictions|DenyDeviceClasses",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceInstall\\Restrictions\\DenyDeviceClasses",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceInstall\\Restrictions|DenyDeviceClassesRetroactive",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceInstall\\Restrictions\\DenyDeviceClassesRetroactive",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceInstall\\Restrictions\\DenyDeviceClasses|**delvals.",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceInstall\\Restrictions\\DenyDeviceClasses\\**delvals.",
+        "Is Compliant": true,
+        "Current Value": "\" \"",
+        "Expected Value": " ",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceInstall\\Restrictions\\DenyDeviceClasses|1",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceInstall\\Restrictions\\DenyDeviceClasses\\1",
+        "Is Compliant": true,
+        "Current Value": "\"{d48179be-ec20-11d1-b6b8-00c04fa372a7}\"",
+        "Expected Value": "{d48179be-ec20-11d1-b6b8-00c04fa372a7}",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|System\\CurrentControlSet\\Policies\\Microsoft\\FVE|RDVDenyWriteAccess",
+        "Friendly Name": "System\\CurrentControlSet\\Policies\\Microsoft\\FVE\\RDVDenyWriteAccess",
+        "Is Compliant": false,
+        "Current Value": "Not Found",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard|EnableVirtualizationBasedSecurity",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard\\EnableVirtualizationBasedSecurity",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard|RequirePlatformSecurityFeatures",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard\\RequirePlatformSecurityFeatures",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard|HypervisorEnforcedCodeIntegrity",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard\\HypervisorEnforcedCodeIntegrity",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard|HVCIMATRequired",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard\\HVCIMATRequired",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard|LsaCfgFlags",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard\\LsaCfgFlags",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard|MachineIdentityIsolation",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard\\MachineIdentityIsolation",
+        "Is Compliant": false,
+        "Current Value": "2",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard|ConfigureSystemGuardLaunch",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard\\ConfigureSystemGuardLaunch",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard|ConfigureKernelShadowStacksLaunch",
+        "Friendly Name": "SOFTWARE\\Policies\\Microsoft\\Windows\\DeviceGuard\\ConfigureKernelShadowStacksLaunch",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Control Panel|FormSuggest Passwords",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Control Panel\\FormSuggest Passwords",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main|FormSuggest PW Ask",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FormSuggest PW Ask",
+        "Is Compliant": true,
+        "Current Value": "\"no\"",
+        "Expected Value": "no",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Internet Explorer\\Main|FormSuggest Passwords",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Internet Explorer\\Main\\FormSuggest Passwords",
+        "Is Compliant": true,
+        "Current Value": "\"no\"",
+        "Expected Value": "no",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CloudContent|DisableThirdPartySuggestions",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CloudContent\\DisableThirdPartySuggestions",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\PushNotifications|NoToastApplicationNotificationOnLockScreen",
+        "Friendly Name": "Software\\Policies\\Microsoft\\Windows\\CurrentVersion\\PushNotifications\\NoToastApplicationNotificationOnLockScreen",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "SystemAccess|LSAAnonymousNameLookup",
+        "Friendly Name": "LSAAnonymousNameLookup",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "SystemAccess"
+      },
+      {
+        "ID": "SystemAccess|MinimumPasswordLength",
+        "Friendly Name": "MinimumPasswordLength",
+        "Is Compliant": true,
+        "Current Value": "14",
+        "Expected Value": "14",
+        "Source": "SystemAccess"
+      },
+      {
+        "ID": "SystemAccess|PasswordComplexity",
+        "Friendly Name": "PasswordComplexity",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SystemAccess"
+      },
+      {
+        "ID": "SystemAccess|PasswordHistorySize",
+        "Friendly Name": "PasswordHistorySize",
+        "Is Compliant": true,
+        "Current Value": "24",
+        "Expected Value": "24",
+        "Source": "SystemAccess"
+      },
+      {
+        "ID": "SystemAccess|LockoutBadCount",
+        "Friendly Name": "LockoutBadCount",
+        "Is Compliant": true,
+        "Current Value": "10",
+        "Expected Value": "10",
+        "Source": "SystemAccess"
+      },
+      {
+        "ID": "SystemAccess|ResetLockoutCount",
+        "Friendly Name": "ResetLockoutCount",
+        "Is Compliant": true,
+        "Current Value": "10",
+        "Expected Value": "10",
+        "Source": "SystemAccess"
+      },
+      {
+        "ID": "SystemAccess|LockoutDuration",
+        "Friendly Name": "LockoutDuration",
+        "Is Compliant": true,
+        "Current Value": "10",
+        "Expected Value": "10",
+        "Source": "SystemAccess"
+      },
+      {
+        "ID": "SystemAccess|AllowAdministratorLockout",
+        "Friendly Name": "AllowAdministratorLockout",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SystemAccess"
+      },
+      {
+        "ID": "SystemAccess|ClearTextPassword",
+        "Friendly Name": "ClearTextPassword",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "SystemAccess"
+      },
+      {
+        "ID": "Privilege|SeSecurityPrivilege",
+        "Friendly Name": "SeSecurityPrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeRestorePrivilege",
+        "Friendly Name": "SeRestorePrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeTakeOwnershipPrivilege",
+        "Friendly Name": "SeTakeOwnershipPrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeBackupPrivilege",
+        "Friendly Name": "SeBackupPrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeDenyRemoteInteractiveLogonRight",
+        "Friendly Name": "SeDenyRemoteInteractiveLogonRight",
+        "Is Compliant": false,
+        "Current Value": "*S-1-5-7, *S-1-5-32-546, *S-1-5-20",
+        "Expected Value": "*S-1-5-113",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeCreatePermanentPrivilege",
+        "Friendly Name": "SeCreatePermanentPrivilege",
+        "Is Compliant": true,
+        "Current Value": "(No assignments)",
+        "Expected Value": "(No assignments)",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeManageVolumePrivilege",
+        "Friendly Name": "SeManageVolumePrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeLoadDriverPrivilege",
+        "Friendly Name": "SeLoadDriverPrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeLockMemoryPrivilege",
+        "Friendly Name": "SeLockMemoryPrivilege",
+        "Is Compliant": true,
+        "Current Value": "(No assignments)",
+        "Expected Value": "(No assignments)",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeDenyNetworkLogonRight",
+        "Friendly Name": "SeDenyNetworkLogonRight",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-113",
+        "Expected Value": "*S-1-5-113",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeNetworkLogonRight",
+        "Friendly Name": "SeNetworkLogonRight",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-555, *S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-555, *S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeImpersonatePrivilege",
+        "Friendly Name": "SeImpersonatePrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-99-216390572-1995538116-3857911515-2404958512-2623887229, *S-1-5-6, *S-1-5-32-544, *S-1-5-20, *S-1-5-19",
+        "Expected Value": "*S-1-5-6, *S-1-5-99-216390572-1995538116-3857911515-2404958512-2623887229, *S-1-5-20, *S-1-5-19, *S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeCreateTokenPrivilege",
+        "Friendly Name": "SeCreateTokenPrivilege",
+        "Is Compliant": true,
+        "Current Value": "(No assignments)",
+        "Expected Value": "(No assignments)",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeCreateGlobalPrivilege",
+        "Friendly Name": "SeCreateGlobalPrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-6, *S-1-5-32-544, *S-1-5-20, *S-1-5-19",
+        "Expected Value": "*S-1-5-20, *S-1-5-19, *S-1-5-6, *S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeSystemEnvironmentPrivilege",
+        "Friendly Name": "SeSystemEnvironmentPrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeCreatePagefilePrivilege",
+        "Friendly Name": "SeCreatePagefilePrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeInteractiveLogonRight",
+        "Friendly Name": "SeInteractiveLogonRight",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-545, *S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-545, *S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeRemoteShutdownPrivilege",
+        "Friendly Name": "SeRemoteShutdownPrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeDebugPrivilege",
+        "Friendly Name": "SeDebugPrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeTrustedCredManAccessPrivilege",
+        "Friendly Name": "SeTrustedCredManAccessPrivilege",
+        "Is Compliant": true,
+        "Current Value": "(No assignments)",
+        "Expected Value": "(No assignments)",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeProfileSingleProcessPrivilege",
+        "Friendly Name": "SeProfileSingleProcessPrivilege",
+        "Is Compliant": true,
+        "Current Value": "*S-1-5-32-544",
+        "Expected Value": "*S-1-5-32-544",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeTcbPrivilege",
+        "Friendly Name": "SeTcbPrivilege",
+        "Is Compliant": true,
+        "Current Value": "(No assignments)",
+        "Expected Value": "(No assignments)",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "Privilege|SeEnableDelegationPrivilege",
+        "Friendly Name": "SeEnableDelegationPrivilege",
+        "Is Compliant": true,
+        "Current Value": "(No assignments)",
+        "Expected Value": "(No assignments)",
+        "Source": "Privilege"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|ConsentPromptBehaviorEnhancedAdmin",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|TypeOfAdminApprovalMode",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon|ScRemoveOption",
+        "Friendly Name": "Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|InactivityTimeoutSecs",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": false,
+        "Current Value": "0",
+        "Expected Value": "900",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters|EnablePlainTextPassword",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Lsa|LimitBlankPasswordUse",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Lsa",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Lsa|RestrictAnonymousSAM",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Lsa",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Lsa|RestrictAnonymous",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Lsa",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\LanManServer\\Parameters|RestrictNullSessAccess",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\LanManServer\\Parameters",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Lsa|SCENoApplyLegacyAuditPolicy",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Lsa",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Lsa\\MSV1_0|NTLMMinClientSec",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Lsa\\MSV1_0",
+        "Is Compliant": true,
+        "Current Value": "537395200",
+        "Expected Value": "537395200",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Lsa|LmCompatibilityLevel",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Lsa",
+        "Is Compliant": true,
+        "Current Value": "5",
+        "Expected Value": "5",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Lsa\\MSV1_0|allownullsessionfallback",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Lsa\\MSV1_0",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Lsa\\MSV1_0|NTLMMinServerSec",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Lsa\\MSV1_0",
+        "Is Compliant": true,
+        "Current Value": "537395200",
+        "Expected Value": "537395200",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\Netlogon\\Parameters|requirestrongkey",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\Netlogon\\Parameters",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters|RequireSecuritySignature",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\Netlogon\\Parameters|sealsecurechannel",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\Netlogon\\Parameters",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\Netlogon\\Parameters|requiresignorseal",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\Netlogon\\Parameters",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\Netlogon\\Parameters|signsecurechannel",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\Netlogon\\Parameters",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\LanManServer\\Parameters|requiresecuritysignature",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\LanManServer\\Parameters",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Session Manager|ProtectionMode",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Session Manager",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|ConsentPromptBehaviorAdmin",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|EnableSecureUIAPaths",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|EnableLUA",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|ConsentPromptBehaviorUser",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": false,
+        "Current Value": "1",
+        "Expected Value": "0",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|EnableInstallerDetection",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|FilterAdministratorToken",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System|EnableVirtualization",
+        "Friendly Name": "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\LDAP|LDAPClientIntegrity",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\LDAP",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Control\\Lsa|RestrictRemoteSAM",
+        "Friendly Name": "System\\CurrentControlSet\\Control\\Lsa",
+        "Is Compliant": true,
+        "Current Value": "O:BAG:BAD:(A;;RC;;;BA)",
+        "Expected Value": "O:BAG:BAD:(A;;RC;;;BA)",
+        "Source": "SecurityPolicyRegistry"
+      },
+      {
+        "ID": "SecurityPolicyRegistry|System\\CurrentControlSet\\Services\\Netlogon\\Parameters|DisablePasswordChange",
+        "Friendly Name": "System\\CurrentControlSet\\Services\\Netlogon\\Parameters",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "SecurityPolicyRegistry"
+      }
+    ]
+  },
+  "Microsoft365AppsSecurityBaseline": {
+    "Count": 385,
+    "Items": [
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE|excel.exe",
+        "Friendly Name": "software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "69632",
+        "Expected Value": "69632",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE|mspub.exe",
+        "Friendly Name": "software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "69632",
+        "Expected Value": "69632",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE|powerpnt.exe",
+        "Friendly Name": "software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "69632",
+        "Expected Value": "69632",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE|onenote.exe",
+        "Friendly Name": "software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "69632",
+        "Expected Value": "69632",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE|visio.exe",
+        "Friendly Name": "software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "69632",
+        "Expected Value": "69632",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE|winproj.exe",
+        "Friendly Name": "software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "69632",
+        "Expected Value": "69632",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE|winword.exe",
+        "Friendly Name": "software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "69632",
+        "Expected Value": "69632",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE|outlook.exe",
+        "Friendly Name": "software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "69632",
+        "Expected Value": "69632",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE|msaccess.exe",
+        "Friendly Name": "software\\policies\\microsoft\\internet explorer\\main\\featurecontrol\\FEATURE_RESTRICT_LEGACY_JSCRIPT_PER_SECURITY_ZONE\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "69632",
+        "Expected Value": "69632",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_addon_management\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_http_username_password_disable\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_localmachine_lockdown\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_handling\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_mime_sniffing\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_object_caching\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_activexinstall\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_restrict_filedownload\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_securityband\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_unc_savedfilecheck\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_validate_navigate_url\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_window_restrictions\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|groove.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\groove.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|excel.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\excel.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|mspub.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\mspub.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|powerpnt.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\powerpnt.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|pptview.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\pptview.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|visio.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\visio.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|winproj.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\winproj.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|winword.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\winword.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|outlook.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\outlook.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|spdesign.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\spdesign.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|exprwd.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\exprwd.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|msaccess.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\msaccess.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|onenote.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\onenote.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation|mse7.exe",
+        "Friendly Name": "software\\microsoft\\internet explorer\\main\\featurecontrol\\feature_zone_elevation\\mse7.exe",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}|ActivationFilterOverride",
+        "Friendly Name": "software\\microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}\\ActivationFilterOverride",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}|Compatibility Flags",
+        "Friendly Name": "software\\microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}\\Compatibility Flags",
+        "Is Compliant": true,
+        "Current Value": "1024",
+        "Expected Value": "1024",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}|ActivationFilterOverride",
+        "Friendly Name": "software\\microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}\\ActivationFilterOverride",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}|Compatibility Flags",
+        "Friendly Name": "software\\microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}\\Compatibility Flags",
+        "Is Compliant": true,
+        "Current Value": "1024",
+        "Expected Value": "1024",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\Office\\Common\\COM Compatibility|Comment",
+        "Friendly Name": "software\\microsoft\\Office\\Common\\COM Compatibility\\Comment",
+        "Is Compliant": true,
+        "Current Value": "\"Block all Flash activation\"",
+        "Expected Value": "Block all Flash activation",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\Office\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}|ActivationFilterOverride",
+        "Friendly Name": "software\\microsoft\\Office\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}\\ActivationFilterOverride",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\Office\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}|Compatibility Flags",
+        "Friendly Name": "software\\microsoft\\Office\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}\\Compatibility Flags",
+        "Is Compliant": true,
+        "Current Value": "1024",
+        "Expected Value": "1024",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\Office\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}|ActivationFilterOverride",
+        "Friendly Name": "software\\microsoft\\Office\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}\\ActivationFilterOverride",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\microsoft\\Office\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}|Compatibility Flags",
+        "Friendly Name": "software\\microsoft\\Office\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}\\Compatibility Flags",
+        "Is Compliant": true,
+        "Current Value": "1024",
+        "Expected Value": "1024",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\lync|disablehttpconnect",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\lync\\disablehttpconnect",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\lync|enablesiphighsecuritymode",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\lync\\enablesiphighsecuritymode",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\WOW6432Node\\Microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}|ActivationFilterOverride",
+        "Friendly Name": "software\\WOW6432Node\\Microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}\\ActivationFilterOverride",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\WOW6432Node\\Microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}|Compatibility Flags",
+        "Friendly Name": "software\\WOW6432Node\\Microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}\\Compatibility Flags",
+        "Is Compliant": true,
+        "Current Value": "1024",
+        "Expected Value": "1024",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\WOW6432Node\\Microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}|ActivationFilterOverride",
+        "Friendly Name": "software\\WOW6432Node\\Microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}\\ActivationFilterOverride",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\WOW6432Node\\Microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}|Compatibility Flags",
+        "Friendly Name": "software\\WOW6432Node\\Microsoft\\Office\\16.0\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}\\Compatibility Flags",
+        "Is Compliant": true,
+        "Current Value": "1024",
+        "Expected Value": "1024",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\WOW6432Node\\Microsoft\\Office\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}|ActivationFilterOverride",
+        "Friendly Name": "software\\WOW6432Node\\Microsoft\\Office\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}\\ActivationFilterOverride",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\WOW6432Node\\Microsoft\\Office\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}|Compatibility Flags",
+        "Friendly Name": "software\\WOW6432Node\\Microsoft\\Office\\Common\\COM Compatibility\\{D27CDB6E-AE6D-11CF-96B8-444553540000}\\Compatibility Flags",
+        "Is Compliant": true,
+        "Current Value": "1024",
+        "Expected Value": "1024",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\WOW6432Node\\Microsoft\\Office\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}|ActivationFilterOverride",
+        "Friendly Name": "software\\WOW6432Node\\Microsoft\\Office\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}\\ActivationFilterOverride",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\WOW6432Node\\Microsoft\\Office\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}|Compatibility Flags",
+        "Friendly Name": "software\\WOW6432Node\\Microsoft\\Office\\Common\\COM Compatibility\\{D27CDB70-AE6D-11CF-96B8-444553540000}\\Compatibility Flags",
+        "Is Compliant": true,
+        "Current Value": "1024",
+        "Expected Value": "1024",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\access\\security|vbawarnings",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\access\\security\\vbawarnings",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\access\\security|vbadigsigtrustedpublishers",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\access\\security\\vbadigsigtrustedpublishers",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\access\\security|vbarequirelmtrustedpublisher",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\access\\security\\vbarequirelmtrustedpublisher",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\access\\security|vbarequiredigsigwithcodesigningeku",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\access\\security\\vbarequiredigsigwithcodesigningeku",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|vbawarnings",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\vbawarnings",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|xl4macrowarningfollowvba",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\xl4macrowarningfollowvba",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|vbadigsigtrustedpublishers",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\vbadigsigtrustedpublishers",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|vbarequirelmtrustedpublisher",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\vbarequirelmtrustedpublisher",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|vbarequiredigsigwithcodesigningeku",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\vbarequiredigsigwithcodesigningeku",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|xl4macrooff",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\xl4macrooff",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\ms project\\security|vbawarnings",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\ms project\\security\\vbawarnings",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|vbawarnings",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\vbawarnings",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|vbadigsigtrustedpublishers",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\vbadigsigtrustedpublishers",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|vbarequirelmtrustedpublisher",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\vbarequirelmtrustedpublisher",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|vbarequiredigsigwithcodesigningeku",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\vbarequiredigsigwithcodesigningeku",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\publisher\\security|vbawarnings",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\publisher\\security\\vbawarnings",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\publisher\\security|vbadigsigtrustedpublishers",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\publisher\\security\\vbadigsigtrustedpublishers",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\publisher\\security|vbarequirelmtrustedpublisher",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\publisher\\security\\vbarequirelmtrustedpublisher",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\publisher\\security|vbarequiredigsigwithcodesigningeku",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\publisher\\security\\vbarequiredigsigwithcodesigningeku",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security|vbawarnings",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\vbawarnings",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security|vbadigsigtrustedpublishers",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\vbadigsigtrustedpublishers",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security|vbarequirelmtrustedpublisher",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\vbarequirelmtrustedpublisher",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security|vbarequiredigsigwithcodesigningeku",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\vbarequiredigsigwithcodesigningeku",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security|vbawarnings",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\vbawarnings",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security|vbadigsigtrustedpublishers",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\vbadigsigtrustedpublishers",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security|vbarequirelmtrustedpublisher",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\vbarequirelmtrustedpublisher",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security|vbarequiredigsigwithcodesigningeku",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\vbarequiredigsigwithcodesigningeku",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\external content|disableddeserverlaunch",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\external content\\disableddeserverlaunch",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\external content|disableddeserverlookup",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\external content\\disableddeserverlookup",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security|**del.allowdde",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\**del.allowdde",
+        "Is Compliant": true,
+        "Current Value": "\" \"",
+        "Expected Value": " ",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|dbasefiles",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\dbasefiles",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|difandsylkfiles",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\difandsylkfiles",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl2macros",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl2macros",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl2worksheets",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl2worksheets",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl3macros",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl3macros",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl3worksheets",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl3worksheets",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl4macros",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl4macros",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl4workbooks",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl4workbooks",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl4worksheets",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl4worksheets",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl95workbooks",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl95workbooks",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl9597workbooksandtemplates",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl9597workbooksandtemplates",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|openinprotectedview",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\openinprotectedview",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|htmlandxmlssfiles",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\htmlandxmlssfiles",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|xl97workbooksandtemplates",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\xl97workbooksandtemplates",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock|fileblockexternallinks",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\fileblock\\fileblockexternallinks",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\fileblock|openinprotectedview",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\fileblock\\openinprotectedview",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\fileblock|binaryfiles",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\fileblock\\binaryfiles",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security\\fileblock|visio2000files",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\fileblock\\visio2000files",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security\\fileblock|visio2003files",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\fileblock\\visio2003files",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security\\fileblock|visio50andearlierfiles",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\fileblock\\visio50andearlierfiles",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock|openinprotectedview",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock\\openinprotectedview",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock|word2files",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock\\word2files",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock|word60files",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock\\word60files",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock|word95files",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock\\word95files",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock|word97files",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock\\word97files",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock|word2000files",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock\\word2000files",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock|word2003files",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock\\word2003files",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock|word2007files",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock\\word2007files",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock|wordxpfiles",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\fileblock\\wordxpfiles",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\access\\security|notbpromptunsignedaddin",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\access\\security\\notbpromptunsignedaddin",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\access\\security|blockcontentexecutionfrominternet",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\access\\security\\blockcontentexecutionfrominternet",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\access\\security\\trusted locations|allownetworklocations",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\access\\security\\trusted locations\\allownetworklocations",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common|fbabehavior",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\fbabehavior",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common|fbaenabledhosts",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\fbaenabledhosts",
+        "Is Compliant": true,
+        "Current Value": "",
+        "Expected Value": "",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\drm|compatibleencryption",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\drm\\compatibleencryption",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\fileio|blockinsecureprotocols",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\fileio\\blockinsecureprotocols",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\fileio|blockwecfallback",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\fileio\\blockwecfallback",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\identity|basicauthproxybehavior",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\identity\\basicauthproxybehavior",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\portal|linkpublishingdisabled",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\portal\\linkpublishingdisabled",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\security|drmencryptproperty",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\security\\drmencryptproperty",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\security|openxmlencryption",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\security\\openxmlencryption",
+        "Is Compliant": true,
+        "Current Value": "\"Microsoft Enhanced RSA and AES Cryptographic Provider,AES 256,256\"",
+        "Expected Value": "Microsoft Enhanced RSA and AES Cryptographic Provider,AES 256,256",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\security|defaultencryption12",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\security\\defaultencryption12",
+        "Is Compliant": true,
+        "Current Value": "\"Microsoft Enhanced RSA and AES Cryptographic Provider,AES 256,256\"",
+        "Expected Value": "Microsoft Enhanced RSA and AES Cryptographic Provider,AES 256,256",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\security|macroruntimescanscope",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\security\\macroruntimescanscope",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\security|blockolegraph",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\security\\blockolegraph",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\security|blockorgchart",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\security\\blockorgchart",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\security\\trusted locations|allow user locations",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\security\\trusted locations\\allow user locations",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\access|noextensibilitycustomizationfromdocument",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\access\\noextensibilitycustomizationfromdocument",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\excel|noextensibilitycustomizationfromdocument",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\excel\\noextensibilitycustomizationfromdocument",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\infopath|noextensibilitycustomizationfromdocument",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\infopath\\noextensibilitycustomizationfromdocument",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\outlook|noextensibilitycustomizationfromdocument",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\outlook\\noextensibilitycustomizationfromdocument",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\powerpoint|noextensibilitycustomizationfromdocument",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\powerpoint\\noextensibilitycustomizationfromdocument",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\project|noextensibilitycustomizationfromdocument",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\project\\noextensibilitycustomizationfromdocument",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\publisher|noextensibilitycustomizationfromdocument",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\publisher\\noextensibilitycustomizationfromdocument",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\visio|noextensibilitycustomizationfromdocument",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\visio\\noextensibilitycustomizationfromdocument",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\word|noextensibilitycustomizationfromdocument",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\toolbars\\word\\noextensibilitycustomizationfromdocument",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\common\\trustcenter|trustbar",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\common\\trustcenter\\trustbar",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\internet|donotloadpictures",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\internet\\donotloadpictures",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\options|extractdatadisableui",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\options\\extractdatadisableui",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\options|disableautorepublish",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\options\\disableautorepublish",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\options|disableautorepublishwarning",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\options\\disableautorepublishwarning",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\options\\binaryoptions|fupdateext_78_1",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\options\\binaryoptions\\fupdateext_78_1",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|extensionhardening",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\extensionhardening",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|excelbypassencryptedmacroscan",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\excelbypassencryptedmacroscan",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|notbpromptunsignedaddin",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\notbpromptunsignedaddin",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|webservicefunctionwarnings",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\webservicefunctionwarnings",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|blockcontentexecutionfrominternet",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\blockcontentexecutionfrominternet",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|requireaddinsig",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\requireaddinsig",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security|blockxllfrominternet",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\blockxllfrominternet",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\external content|enableblockunsecurequeryfiles",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\external content\\enableblockunsecurequeryfiles",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\filevalidation|enableonload",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\filevalidation\\enableonload",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\filevalidation|disableeditfrompv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\filevalidation\\disableeditfrompv",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\filevalidation|openinprotectedview",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\filevalidation\\openinprotectedview",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\protectedview|disableattachmentsinpv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\protectedview\\disableattachmentsinpv",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\protectedview|disableinternetfilesinpv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\protectedview\\disableinternetfilesinpv",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\protectedview|disableunsafelocationsinpv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\protectedview\\disableunsafelocationsinpv",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\protectedview|enabledatabasefileprotectedview",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\protectedview\\enabledatabasefileprotectedview",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\excel\\security\\trusted locations|allownetworklocations",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\excel\\security\\trusted locations\\allownetworklocations",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\ms project\\security|notbpromptunsignedaddin",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\ms project\\security\\notbpromptunsignedaddin",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\ms project\\security|requireaddinsig",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\ms project\\security\\requireaddinsig",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\ms project\\security|blockcontentexecutionfrominternet",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\ms project\\security\\blockcontentexecutionfrominternet",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\ms project\\security\\trusted locations|allownetworklocations",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\ms project\\security\\trusted locations\\allownetworklocations",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook|disallowattachmentcustomization",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\disallowattachmentcustomization",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\options\\general|msgformat",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\options\\general\\msgformat",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\options\\mail|junkmailenablelinks",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\options\\mail\\junkmailenablelinks",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\options\\mail|internet",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\options\\mail\\internet",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\rpc|enablerpcencryption",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\rpc\\enablerpcencryption",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|promptoomformulaaccess",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\promptoomformulaaccess",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|promptoomsaveas",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\promptoomsaveas",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|promptoomaddressbookaccess",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\promptoomaddressbookaccess",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|promptoomaddressinformationaccess",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\promptoomaddressinformationaccess",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|promptoommeetingtaskrequestresponse",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\promptoommeetingtaskrequestresponse",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|promptoomsend",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\promptoomsend",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|minenckey",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\minenckey",
+        "Is Compliant": true,
+        "Current Value": "168",
+        "Expected Value": "168",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|warnaboutinvalid",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\warnaboutinvalid",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|showlevel1attach",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\showlevel1attach",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|promptoomcustomaction",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\promptoomcustomaction",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|enableoneoffformscripts",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\enableoneoffformscripts",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|allowactivexoneoffforms",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\allowactivexoneoffforms",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|usecrlchasing",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\usecrlchasing",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|publicfolderscript",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\publicfolderscript",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|adminsecuritymode",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\adminsecuritymode",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|allowuserstolowerattachments",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\allowuserstolowerattachments",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|sharedfolderscript",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\sharedfolderscript",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|authenticationservice",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\authenticationservice",
+        "Is Compliant": true,
+        "Current Value": "16",
+        "Expected Value": "16",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|level",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\level",
+        "Is Compliant": true,
+        "Current Value": "3",
+        "Expected Value": "3",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|fileextensionsremovelevel1",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\fileextensionsremovelevel1",
+        "Is Compliant": true,
+        "Current Value": "\";\"",
+        "Expected Value": ";",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\outlook\\security|fileextensionsremovelevel2",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\outlook\\security\\fileextensionsremovelevel2",
+        "Is Compliant": true,
+        "Current Value": "\";\"",
+        "Expected Value": ";",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|notbpromptunsignedaddin",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\notbpromptunsignedaddin",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|powerpointbypassencryptedmacroscan",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\powerpointbypassencryptedmacroscan",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|runprograms",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\runprograms",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|blockcontentexecutionfrominternet",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\blockcontentexecutionfrominternet",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|requireaddinsig",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\requireaddinsig",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security|**del.enableoleactions",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\**del.enableoleactions",
+        "Is Compliant": true,
+        "Current Value": "\" \"",
+        "Expected Value": " ",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\filevalidation|enableonload",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\filevalidation\\enableonload",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\filevalidation|disableeditfrompv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\filevalidation\\disableeditfrompv",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\filevalidation|openinprotectedview",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\filevalidation\\openinprotectedview",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\protectedview|disableinternetfilesinpv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\protectedview\\disableinternetfilesinpv",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\protectedview|disableunsafelocationsinpv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\protectedview\\disableunsafelocationsinpv",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\protectedview|disableattachmentsinpv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\protectedview\\disableattachmentsinpv",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\trusted locations|allownetworklocations",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\powerpoint\\security\\trusted locations\\allownetworklocations",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\publisher\\security|notbpromptunsignedaddin",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\publisher\\security\\notbpromptunsignedaddin",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\publisher\\security|requireaddinsig",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\publisher\\security\\requireaddinsig",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\publisher\\security|blockcontentexecutionfrominternet",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\publisher\\security\\blockcontentexecutionfrominternet",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security|notbpromptunsignedaddin",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\notbpromptunsignedaddin",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security|blockcontentexecutionfrominternet",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\blockcontentexecutionfrominternet",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security|requireaddinsig",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\requireaddinsig",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\visio\\security\\trusted locations|allownetworklocations",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\visio\\security\\trusted locations\\allownetworklocations",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security|notbpromptunsignedaddin",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\notbpromptunsignedaddin",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security|wordbypassencryptedmacroscan",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\wordbypassencryptedmacroscan",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security|blockcontentexecutionfrominternet",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\blockcontentexecutionfrominternet",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security|requireaddinsig",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\requireaddinsig",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\filevalidation|openinprotectedview",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\filevalidation\\openinprotectedview",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\filevalidation|disableeditfrompv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\filevalidation\\disableeditfrompv",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\filevalidation|enableonload",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\filevalidation\\enableonload",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\protectedview|disableattachmentsinpv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\protectedview\\disableattachmentsinpv",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\protectedview|disableinternetfilesinpv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\protectedview\\disableinternetfilesinpv",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\protectedview|disableunsafelocationsinpv",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\protectedview\\disableunsafelocationsinpv",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\16.0\\word\\security\\trusted locations|allownetworklocations",
+        "Friendly Name": "software\\policies\\microsoft\\office\\16.0\\word\\security\\trusted locations\\allownetworklocations",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\common\\security|automationsecurity",
+        "Friendly Name": "software\\policies\\microsoft\\office\\common\\security\\automationsecurity",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\common\\security|automationsecuritypublisher",
+        "Friendly Name": "software\\policies\\microsoft\\office\\common\\security\\automationsecuritypublisher",
+        "Is Compliant": true,
+        "Current Value": "2",
+        "Expected Value": "2",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\common\\security|uficontrols",
+        "Friendly Name": "software\\policies\\microsoft\\office\\common\\security\\uficontrols",
+        "Is Compliant": true,
+        "Current Value": "6",
+        "Expected Value": "6",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\office\\common\\smart tag|neverloadmanifests",
+        "Friendly Name": "software\\policies\\microsoft\\office\\common\\smart tag\\neverloadmanifests",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\vba\\security|loadcontrolsinforms",
+        "Friendly Name": "software\\policies\\microsoft\\vba\\security\\loadcontrolsinforms",
+        "Is Compliant": true,
+        "Current Value": "1",
+        "Expected Value": "1",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\vba\\security|allowvbaintranetreferences",
+        "Friendly Name": "software\\policies\\microsoft\\vba\\security\\allowvbaintranetreferences",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      },
+      {
+        "ID": "GroupPolicy|software\\policies\\microsoft\\vba\\security|disablestrictvbarefssecurity",
+        "Friendly Name": "software\\policies\\microsoft\\vba\\security\\disablestrictvbarefssecurity",
+        "Is Compliant": true,
+        "Current Value": "0",
+        "Expected Value": "0",
+        "Source": "GroupPolicy"
+      }
+    ]
+  },
+  "MicrosoftDefender": {
+    "Count": 87,
+    "Items": [
+      {
+        "Name": "Enhanced Phishing Protection: Capture Threat Window",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-webthreatdefense#automaticdatacollection",
+        "ID": "019a8dfa-2539-771f-a167-a1af333c15e1"
+      },
+      {
+        "Name": "Enhanced Phishing Protection: Notify Malicious",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-webthreatdefense#notifymalicious",
+        "ID": "019a8dfa-2539-70fc-ab4c-d7f6870fab4d"
+      },
+      {
+        "Name": "Enhanced Phishing Protection: Notify Password Reuse",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-webthreatdefense#notifypasswordreuse",
+        "ID": "019a8dfa-2539-7ef2-a1e3-d568396edd31"
+      },
+      {
+        "Name": "Enhanced Phishing Protection: Notify Unsafe App",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-webthreatdefense#notifyunsafeapp",
+        "ID": "019a8dfa-2539-7cef-b705-29a370bea48d"
+      },
+      {
+        "Name": "Enhanced Phishing Protection Service Enabled.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-webthreatdefense#serviceenabled",
+        "ID": "019a8dfa-2539-71f9-879c-ebfe1703fa8f"
+      },
+      {
+        "Name": "Enable Intel TDT: Threat Detection Technology.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationinteltdtenabled",
+        "ID": "019a8dfa-2539-7914-a492-6739cf39221f"
+      },
+      {
+        "Name": "Set the Cloud Block Level to the maximum value: No Tolerance.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#cloudblocklevel",
+        "ID": "019a8dfa-253a-783f-8a61-382f9561aabe"
+      },
+      {
+        "Name": "Extended cloud check timeout set to maximum value.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#cloudextendedtimeout",
+        "ID": "019a8dfa-253a-73c8-b94a-0ddf909a3936"
+      },
+      {
+        "Name": "Enable calculation of File Hashes.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-microsoftdefenderantivirus#mpengine_enablefilehashcomputation",
+        "ID": "019a8dfa-253a-72cb-90b1-3982f62cc84a"
+      },
+      {
+        "Name": "Purge Items After Delay",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-microsoftdefenderantivirus#quarantine_purgeitemsafterdelay",
+        "ID": "019a8dfa-253a-7690-87ab-733e43c03d43"
+      },
+      {
+        "Name": "Disable Dev Drive's lax security around file scanning.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/microsoft-defender-endpoint-antivirus-performance-mode",
+        "ID": "019a8dfa-253a-7eb5-ad3c-e178b3c09b1b"
+      },
+      {
+        "Name": "Enable RTP And Signature Update during OOBE mode.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationoobeenablertpandsigupdate",
+        "ID": "019a8dfa-253a-77fe-bb82-30b421c9f7b3"
+      },
+      {
+        "Name": "Maximum size of downloaded files and attachments to be scanned",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-microsoftdefenderantivirus#realtimeprotection_ioavmaxsize",
+        "ID": "019a8dfa-253a-78de-be06-9da3fcf5ca94"
+      },
+      {
+        "Name": "Enable BruteForce Protection feature.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationbehavioralnetworkblocksbruteforceprotectionbruteforceprotectionconfiguredstate",
+        "ID": "019a8dfa-253b-782c-aa43-b81fdb9adfa4"
+      },
+      {
+        "Name": "Configure the Brute Force aggressiveness level to high.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationbehavioralnetworkblocksbruteforceprotectionbruteforceprotectionaggressiveness",
+        "ID": "019a8dfa-253b-7199-8fdc-5267c2813116"
+      },
+      {
+        "Name": "Enable Remote Encryption Protection feature.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationbehavioralnetworkblocksremoteencryptionprotectionremoteencryptionprotectionconfiguredstate",
+        "ID": "019a8dfa-253b-7130-a348-7aceef12fd1d"
+      },
+      {
+        "Name": "Configure the Remote Encryption Protection aggressiveness level to high.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationbehavioralnetworkblocksremoteencryptionprotectionremoteencryptionprotectionaggressiveness",
+        "ID": "019a8dfa-253b-7227-994d-195a4efe326c"
+      },
+      {
+        "Name": "Maximum depth to scan archive files",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-microsoftdefenderantivirus#scan_archivemaxdepth",
+        "ID": "019a8dfa-253b-7894-b96f-84ccbbf2f9f6"
+      },
+      {
+        "Name": "Removable Drive Scanning",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#allowfullscanremovabledrivescanning",
+        "ID": "019a8dfa-253b-7090-8527-b85cc001b1a2"
+      },
+      {
+        "Name": "Reparse Point Scanning",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-microsoftdefenderantivirus#scan_disablereparsepointscanning",
+        "ID": "019a8dfa-253b-7e41-a892-8c5659f5487b"
+      },
+      {
+        "Name": "Scanning Mapped Network Drives For Full Scan",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#allowfullscanonmappednetworkdrives",
+        "ID": "019a8dfa-253c-7583-a297-6afc4131fa78"
+      },
+      {
+        "Name": "Scanning Network Files",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#allowscanningnetworkfiles",
+        "ID": "019a8dfa-253c-7e57-a51a-f2c7f9729cb9"
+      },
+      {
+        "Name": "Enable Email Scanning.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#allowemailscanning",
+        "ID": "019a8dfa-253c-787b-be5f-a715bda3cef1"
+      },
+      {
+        "Name": "Enable Catchup Quick Scans.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#disablecatchupquickscan",
+        "ID": "019a8dfa-253c-7630-844a-6807e10f86bb"
+      },
+      {
+        "Name": "Check For Signatures Before Running a Scan.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#checkforsignaturesbeforerunningscan",
+        "ID": "019a8dfa-253c-7e41-b315-7aea71c6927c"
+      },
+      {
+        "Name": "Increase the interval to check for security intelligence updates.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#signatureupdateinterval",
+        "ID": "019a8dfa-253c-736b-a77d-f4fbad6dc3a2"
+      },
+      {
+        "Name": "Check for the latest virus and spyware security intelligence on startup",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-microsoftdefenderantivirus#signatureupdate_updateonstartup",
+        "ID": "019a8dfa-253c-7567-8281-52ce16ee958d"
+      },
+      {
+        "Name": "Allows Microsoft Defender Antivirus to update over a metered connection",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationmeteredconnectionupdates",
+        "ID": "019a8dfa-253d-7f17-be4d-f58ed4423e79"
+      },
+      {
+        "Name": "Define the number of days before spyware security intelligence is considered out of date",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-microsoftdefenderantivirus#signatureupdate_assignaturedue",
+        "ID": "019a8dfa-253d-76ad-9fc2-41115fe19ce2"
+      },
+      {
+        "Name": "Define the number of days before virus security intelligence is considered out of date",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-microsoftdefenderantivirus#signatureupdate_avsignaturedue",
+        "ID": "019a8dfa-253d-7bb0-bf13-89f4fdec59bc"
+      },
+      {
+        "Name": "Enable the Block At First Sight feature.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-microsoftdefenderantivirus#disableblockatfirstseen",
+        "ID": "019a8dfa-253d-7c14-9a37-13004e5bdede"
+      },
+      {
+        "Name": "Join the Microsoft MAPS (also known as SpyNet) network to stay up to date with the latest security intelligence.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#allowcloudprotection",
+        "ID": "019a8dfa-253d-7a0e-940d-0722abdc4567"
+      },
+      {
+        "Name": "Send file samples when further analysis is required",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#submitsamplesconsent",
+        "ID": "019a8dfa-253d-7f1d-ac07-2a2afd4e4185"
+      },
+      {
+        "Name": "Configure default actions for threat severities",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#threatseveritydefaultaction",
+        "ID": "019a8dfa-253d-71f4-bc7f-8ccf25a44996"
+      },
+      {
+        "Name": "Low Threat level default action = Quarantine",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#threatseveritydefaultaction",
+        "ID": "019a8dfa-253d-724c-a066-8cbbdb979586"
+      },
+      {
+        "Name": "Moderate Threat level default action = Quarantine",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#threatseveritydefaultaction",
+        "ID": "019a8dfa-253d-7db4-81ae-08868c64b5d7"
+      },
+      {
+        "Name": "High Threat level default action = Remove",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#threatseveritydefaultaction",
+        "ID": "019a8dfa-253e-7abb-a823-147f7b686081"
+      },
+      {
+        "Name": "Severe Threat level default action = Remove",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#threatseveritydefaultaction",
+        "ID": "019a8dfa-253e-77b5-b7ef-922b599f3ae2"
+      },
+      {
+        "Name": "Enable Controlled Folder Access",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/enable-controlled-folders",
+        "ID": "019a8dfa-253e-747b-b326-0c9523a6ae37"
+      },
+      {
+        "Name": "Enable Network Protection",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#enablenetworkprotection",
+        "ID": "019a8dfa-253e-7f03-bd1e-cd16590f1a2b"
+      },
+      {
+        "Name": "Enable Network Protection on Windows Server",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationallownetworkprotectiononwinserver",
+        "ID": "019a8dfa-253e-70cb-a6bd-32abb093a820"
+      },
+      {
+        "Name": "Optional Diagnostic Data Required for Smart App Control etc.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "MSDefender_OptionalDiagnosticData",
+        "SubCategoryName": "Optional Diagnostic Data",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-system#allowtelemetry",
+        "ID": "019a8dfa-253e-764f-acd5-d26c2c0e3d6c"
+      },
+      {
+        "Name": "Configure diagnostic data opt-in settings user interface",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "MSDefender_OptionalDiagnosticData",
+        "SubCategoryName": "Optional Diagnostic Data",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-system#configuretelemetryoptinsettingsux",
+        "ID": "019a8dfa-253e-7bef-95cc-a7277deae4cd"
+      },
+      {
+        "Name": "Turn on Smart App Control. Please also enable optional diagnostic data which is needed for proper functioning of Smart App Control.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "MSDefender_SmartAppControl",
+        "SubCategoryName": "Smart App Control",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/apps/develop/smart-app-control/overview",
+        "ID": "019a8dfa-253e-767c-b531-de109f3929d8"
+      },
+      {
+        "Name": "Set the maximum time an IP address is blocked by Brute-Force Protection to the maximum possible value. After this time, blocked IP addresses will be able to sign-in and initiate sessions.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationbehavioralnetworkblocksbruteforceprotectionbruteforceprotectionmaxblocktime",
+        "ID": "019a8dfa-253f-7bab-a801-a65d8f334260"
+      },
+      {
+        "Name": "Set the maximum time an IP address is blocked by Remote Encryption Protection to the maximum possible value. After this time, blocked IP addresses will be able to initiate connection.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/en-us/windows/client-management/mdm/defender-csp#configurationbehavioralnetworkblocksremoteencryptionprotectionremoteencryptionprotectionmaxblocktime",
+        "ID": "019ab6f0-79fa-7f0c-891b-84d4db119bf6"
+      },
+      {
+        "Name": "Enable detection for potentially unwanted applications. They will show in Microsoft Defender history along with other threats.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-defender#puaprotection",
+        "ID": "019ab74b-7b27-7594-a31b-66b2d5157929"
+      },
+      {
+        "Name": "Enable Restore point scan",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation",
+          "School"
+        ],
+        "ID": "019a9060-c319-742a-8ee6-f31481846eaa"
+      },
+      {
+        "Name": "Optimize Network Protection Performance of the Microsoft Defender by making it asynchronous.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "ID": "019a9060-e172-7876-885d-633d2dbd65eb"
+      },
+      {
+        "Name": "Set the Network Protection to block network traffic instead of displaying a warning",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation",
+          "School"
+        ],
+        "ID": "019a9061-41b0-7baa-afc8-b253b43025fd"
+      },
+      {
+        "Name": "Extend brute-force protection coverage to block local network addresses.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation",
+          "School"
+        ],
+        "ID": "019a9061-8aba-789f-9291-fa4fd6464fda"
+      },
+      {
+        "Name": "Add OneDrive folders of all the user accounts (personal and work accounts) to the Controlled Folder Access for Ransomware Protection",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "ID": "019a9061-ff1a-7c33-9152-2395ed108dfe"
+      },
+      {
+        "Name": "Enable Mandatory ASLR Exploit Protection System-wide",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation",
+          "School"
+        ],
+        "URL": "https://support.microsoft.com/office/how-onedrive-safeguards-your-data-in-the-cloud-23c6ea94-3608-48d7-8bf0-80e142edd1e1",
+        "ID": "019a9062-247e-7b49-a029-e2e3917b7ba9"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: msedge.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3c-2def-78a2-94dd-36051c051214"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: explorer.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3c-6aec-7fb5-9be8-2a9043740737"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: vmcompute.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3c-ec59-78a1-930a-2128dafb7c11"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: vmwp.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3d-3a49-79f9-bdbd-6aa68d3dfdbc"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: QuickAssist.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3d-83d1-7451-91f9-93a844f004e3"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: Acrobat.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3d-c992-7dc9-8a8e-9da49131bb49"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: OneDrive.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3e-00a1-723f-b191-db80c9f5a2cb"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: EXCEL.EXE",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3e-305d-7133-8dd3-13c1f9563dcc"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: MSACCESS.EXE",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3e-6298-7b36-a2bc-166e911c96b1"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: MSPUB.EXE",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3e-9962-7403-97ed-cd7cab2050d7"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: ONENOTE.EXE",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3e-cf63-7a82-9c31-3a07889d065e"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: OUTLOOK.EXE",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3f-070e-7f40-aee7-43d6027846a4"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: POWERPNT.EXE",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3f-363b-7d10-a8d7-3ee3456cbdeb"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: WINWORD.EXE",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3f-634a-79aa-ac2f-f701c87abc0f"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: lsass.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3f-99c0-7474-bfdf-8b62b9669627"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: SmartScreen.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3f-c76c-7fd0-b249-38e45ce99401"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: Regsvr32.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e3f-f72d-7534-980d-32341781fc17"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: WindowsSandbox.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e40-247e-770d-abdd-7c857afda2e2"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: WindowsSandboxClient.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e40-799b-7260-b5dd-a5c2bef2c69d"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: RuntimeBroker.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e40-bb74-7c8c-ad7e-06d3f92bac3b"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: msedgewebview2.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e40-ed48-7b1b-abc4-0ab9f4795eab"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: csrss.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e41-285f-7a02-81b9-0c9a1e8e3c85"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: services.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e41-5302-7dac-8b2f-8ead5e2ce790"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: rundll32.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e41-7d6b-741f-8aaf-5518ca4c2b91"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: SMSS.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e41-a4a1-7016-9d7c-72dbf68b9022"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: Wininit.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e41-e230-78b3-a44b-9f4ee3701f2a"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: NisSrv.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e42-0bd6-70b4-8e15-7392f5338912"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: AppControlManager.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e42-4738-79d8-8aca-c3431a5409cf"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: HardenSystemSecurity.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e42-6832-75a2-b90a-8258966d746a"
+      },
+      {
+        "Name": "Apply the Process Mitigations for: QuantumRelayHSS.exe",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/exploit-protection-reference",
+        "ID": "019a8e42-b158-7d86-875d-939556db6102"
+      },
+      {
+        "Name": "Turn on Data Execution Prevention (DEP) for all applications, including 32-bit programs.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "ID": "019a9062-6faa-7196-9f28-0b3e8b67abad"
+      },
+      {
+        "Name": "Exclude incompatible GitHub Desktop, Git, and MSYS2 executables from the system-wide Mandatory ASLR.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development"
+        ],
+        "ID": "019a9062-e303-7f26-85db-29b45813cfa3"
+      },
+      {
+        "Name": "Configure the Microsoft Defender Engine and Platform update channels to beta.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "MSDefender_BetaUpdateChannelsForDefender",
+        "SubCategoryName": "Beta Update Channels For Defender",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation"
+        ],
+        "ID": "019a9063-39db-7eb4-b5c3-99394df239c4"
+      },
+      {
+        "Name": "Run Microsoft Defender Antivirus in a sandbox for enhanced protection against tampering.",
+        "Category": "MicrosoftDefender",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/defender-endpoint/sandbox-mdav",
+        "ID": "019a9063-824a-71a0-9564-1618d602830c"
+      }
+    ]
+  },
+  "AttackSurfaceReductionRules": {
+    "Count": 19,
+    "Items": [
+      {
+        "name": "Block abuse of exploited vulnerable signed drivers",
+        "state": "Warn",
+        "id": "019a8dfa-2283-7583-9d3d-eef55fc17142"
+      },
+      {
+        "name": "Block Adobe Reader from creating child processes",
+        "state": "Block",
+        "id": "019a8dfa-2283-7aef-aada-c8eb7f1b003b"
+      },
+      {
+        "name": "Block all Office applications from creating child processes",
+        "state": "Block",
+        "id": "019a8dfa-2283-792e-8d1c-98ade50b6ce5"
+      },
+      {
+        "name": "Block credential stealing from the Windows local security authority subsystem (lsass.exe)",
+        "state": "Block",
+        "id": "019a8dfa-2284-7370-8376-2e59d4907a56"
+      },
+      {
+        "name": "Block executable content from email client and webmail",
+        "state": "Warn",
+        "id": "019a8dfa-2284-7fcf-a1c2-71b08f5a598d"
+      },
+      {
+        "name": "Block executable files from running unless they meet a prevalence, age, or trusted list criterion",
+        "state": "Warn",
+        "id": "019a8dfa-2284-796c-8eac-268868014e05"
+      },
+      {
+        "name": "Block execution of potentially obfuscated scripts",
+        "state": "Block",
+        "id": "019a8dfa-2284-7171-8e55-2fd43b1d9e5b"
+      },
+      {
+        "name": "Block JavaScript or VBScript from launching downloaded executable content",
+        "state": "Warn",
+        "id": "019a8dfa-2284-7ffe-8cb2-d4f0ebf8d250"
+      },
+      {
+        "name": "Block Office applications from creating executable content",
+        "state": "Warn",
+        "id": "019a8dfa-2285-7933-bef9-6d56b4390648"
+      },
+      {
+        "name": "Block Office applications from injecting code into other processes",
+        "state": "Warn",
+        "id": "019a8dfa-2285-7218-89fc-79d12cb1943f"
+      },
+      {
+        "name": "Block Office communication application from creating child processes",
+        "state": "Block",
+        "id": "019a8dfa-2285-7c27-8822-10b47a92ae8e"
+      },
+      {
+        "name": "Block persistence through WMI event subscription\n* File and folder exclusions not supported.",
+        "state": "Block",
+        "id": "019a8dfa-2285-7d1b-b362-d0d5203607b1"
+      },
+      {
+        "name": "Block process creations originating from PSExec and WMI commands",
+        "state": "Warn",
+        "id": "019a8dfa-2285-7856-afa4-39b8afe0b180"
+      },
+      {
+        "name": "Block untrusted and unsigned processes that run from USB",
+        "state": "Warn",
+        "id": "019a8dfa-2286-71de-b501-0114ce160a30"
+      },
+      {
+        "name": "Block Win32 API calls from Office macros",
+        "state": "Warn",
+        "id": "019a8dfa-2286-7d14-8547-ae6671582dd4"
+      },
+      {
+        "name": "Use advanced protection against ransomware",
+        "state": "Warn",
+        "id": "019a8dfa-2287-7980-8f29-77221ade4a59"
+      },
+      {
+        "name": "Block rebooting machine in Safe Mode",
+        "state": "NotConfigured",
+        "id": "019a8dfa-2287-7228-9b82-ca1c483e3d05"
+      },
+      {
+        "name": "Block use of copied or impersonated system tools",
+        "state": "Warn",
+        "id": "019a8dfa-2287-7d1b-81e1-e3eeea8cf336"
+      },
+      {
+        "name": "Block Webshell creation for Servers",
+        "state": "Block",
+        "id": "019a8dfa-2288-73df-a213-f4491efbabf8"
+      }
+    ]
+  },
+  "BitLockerSettings": {
+    "Count": 21,
+    "Items": [
+      {
+        "Name": "Configure secure encryption type for Fixed Data Drives",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#fixeddrivesencryptiontype",
+        "ID": "019a8dfa-2373-7b29-9ca4-1963d53b4c0f"
+      },
+      {
+        "Name": "Allow the OS to require additional authentication at startup",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesrequirestartupauthentication",
+        "ID": "019a8dfa-2375-71a5-8af8-bfc25ccdd0f5"
+      },
+      {
+        "Name": "Don't allow BitLocker without TPM",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesrequirestartupauthentication",
+        "ID": "019a8dfa-2376-79ed-8a3c-099118368f4c"
+      },
+      {
+        "Name": "Don't Allow using TPM alone",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesrequirestartupauthentication",
+        "ID": "019a8dfa-2376-770d-9f0e-720a9696ace9"
+      },
+      {
+        "Name": "Allow using TPM + PIN on Startup.",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesrequirestartupauthentication",
+        "ID": "019a8dfa-2377-7c32-bdd7-46ab3864cf90"
+      },
+      {
+        "Name": "Allow using TPM + key on Startup.",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesrequirestartupauthentication",
+        "ID": "019a8dfa-2377-789e-9b1f-d7a16beb0844"
+      },
+      {
+        "Name": "Allow using TPM + Startup Key + PIN on Startup.",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesrequirestartupauthentication",
+        "ID": "019a8dfa-2377-78e6-aa7b-8e973fab2475"
+      },
+      {
+        "Name": "Disallow Standard User PIN Reset",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesdisallowstandarduserscanchangepin",
+        "ID": "019a8dfa-2378-71f2-ae2e-abd8b358ab7b"
+      },
+      {
+        "Name": "Use Enhanced PIN by allowing symbols and other characters to be used in the PIN.",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesenhancedpin",
+        "ID": "019a8dfa-2378-7dd6-8bdf-f07dedef0050"
+      },
+      {
+        "Name": "Configure minimum PIN length for startup.",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesminimumpinlength",
+        "ID": "019a8dfa-2379-757e-8d0b-b056a01b0a74"
+      },
+      {
+        "Name": "Configure secure full disk encryption type for OS drive",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#systemdrivesencryptiontype",
+        "ID": "019a8dfa-237a-7831-9954-14a0bcb42252"
+      },
+      {
+        "Name": "Configure secure full disk encryption type for removable drives",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#removabledrivesencryptiontype",
+        "ID": "019a8dfa-237c-7763-a4c5-f9b256589415"
+      },
+      {
+        "Name": "Configure the correct Encryption method for OS drive: XTS-AES-256",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#encryptionmethodbydrivetype",
+        "ID": "019a8dfa-237e-70ec-9ac0-ace8ac0719b4"
+      },
+      {
+        "Name": "Configure the correct Encryption method for fixed data drives: XTS-AES-256",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#encryptionmethodbydrivetype",
+        "ID": "019a8dfa-2382-70fa-840a-fe285f9b03d4"
+      },
+      {
+        "Name": "Configure the correct Encryption method for removable drives: XTS-AES-256",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/bitlocker-csp#encryptionmethodbydrivetype",
+        "ID": "019a8dfa-2386-711c-9b63-6b01a7160064"
+      },
+      {
+        "Name": "Prevent access to BitLocker-protected removable data drives from earlier versions of Windows",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2388-757f-a9cd-43f3fd2fe7c3"
+      },
+      {
+        "Name": "Do not install \"BitLocker To Go\" Reader on FAT formatted removable drives because they are insecure.",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2389-7dab-8dcb-871867b1af06"
+      },
+      {
+        "Name": "Disallow standby states (S1-S3) when sleeping (plugged in)",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-power#allowstandbywhensleepingpluggedin",
+        "ID": "019a8dfa-238b-7c0f-ac74-a8ac650f9caf"
+      },
+      {
+        "Name": "Disallow standby states (S1-S3) when sleeping (on battery)",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-power#allowstandbystateswhensleepingonbattery",
+        "ID": "019a8dfa-238e-789f-90b6-ef3c56a2237c"
+      },
+      {
+        "Name": "Show Hibernate Option in the power options in the OS so you can hibernate your device if you want.",
+        "Category": "BitLockerSettings",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-windowsexplorer#showhibernateoption",
+        "ID": "019a8dfa-2392-718f-8900-89074493fcd3"
+      },
+      {
+        "Name": "Allow network connectivity during connected-modern-standby (only when plugged in)",
+        "Category": "BitLockerSettings",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-power#acconnectivityinstandby_2",
+        "ID": "019a8dfa-2395-758e-a7c9-ac1bbe9e5d4f"
+      }
+    ]
+  },
+  "TLSSecurity": {
+    "Count": 22,
+    "Items": [
+      {
+        "Name": "Configure the correct TLS Cipher Suites",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-cryptography#tlsciphersuites",
+        "ID": "019a8dfa-2725-71bb-b3ab-1950941755fd"
+      },
+      {
+        "Name": "Configure service ECC Curves and their positions.",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/win32/secauthn/tls-elliptic-curves-in-windows-10-1607-and-later",
+        "ID": "019a8dfa-2725-764b-b396-7948bc3b1e64"
+      },
+      {
+        "Name": "Disable TLS v1 Client - Part 1",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/demystifying-schannel/259233",
+        "ID": "019a8dfa-2725-72a1-abc9-fc8ab07cb796"
+      },
+      {
+        "Name": "Disable TLS v1 Client - Part 2",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/demystifying-schannel/259233",
+        "ID": "019a8dfa-2725-7b84-af76-111c61b31e5c"
+      },
+      {
+        "Name": "Disable TLS v1 Server - Part 1",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/demystifying-schannel/259233",
+        "ID": "019a8dfa-2725-7b21-b7d6-ec48d68ebf17"
+      },
+      {
+        "Name": "Disable TLS v1 Server - Part 2",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/demystifying-schannel/259233",
+        "ID": "019a8dfa-2725-778a-8b84-9c01fe5628f9"
+      },
+      {
+        "Name": "Disable TLS v1.1 Client - Part 1",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/demystifying-schannel/259233",
+        "ID": "019a8dfa-2726-7257-b578-3dd1303a6e02"
+      },
+      {
+        "Name": "Disable TLS v1.1 Client - Part 2",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/demystifying-schannel/259233",
+        "ID": "019a8dfa-2726-7e81-8f10-26f4667aba58"
+      },
+      {
+        "Name": "Disable TLS v1.1 Server - Part 1",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/demystifying-schannel/259233",
+        "ID": "019a8dfa-2726-7bf9-94cd-f2df962b8e5b"
+      },
+      {
+        "Name": "Disable TLS v1.1 Server - Part 2",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://techcommunity.microsoft.com/blog/coreinfrastructureandsecurityblog/demystifying-schannel/259233",
+        "ID": "019a8dfa-2726-7378-be00-e757a80cabbe"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: NULL",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2726-7828-a50b-5258ecfea2cd"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: DES 56-bit",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2726-7b15-ae13-3457fcc0aebf"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: RC2 40-bit",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2727-7887-8fe1-b1e26b4e7f5c"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: RC2 56-bit",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2727-7546-81e3-356fda97db4c"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: RC2 128-bit",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2727-716e-a69b-4ecd2ed21da5"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: RC4 40-bit",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2727-7ea0-bedc-4a0b781efc3c"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: RC4 56-bit",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2727-7f74-a883-0805c8c5ceae"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: RC4 64-bit",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2727-733f-9f95-9b07e7a82658"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: RC4 128-bit",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2728-73c3-ab23-757ff136e9d1"
+      },
+      {
+        "Name": "Disable the weak Cipher for Schannel: 3DES 168-bit (Triple DES 168)",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2728-7297-9b43-f71630e15b9a"
+      },
+      {
+        "Name": "Disable MD5 Hashing Algorithm for SChannel.",
+        "Category": "TLSSecurity",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2728-70b3-a7f7-9b50df8aa3a4"
+      },
+      {
+        "Name": "Allow the less secure \"TLS_RSA_WITH_AES_256_CBC_SHA\" Cipher to be used in order to provide compatibility with the Battle Net game client.",
+        "Category": "TLSSecurity",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "TLS_ForBattleNet",
+        "SubCategoryName": "For Battle Net",
+        "DeviceIntents": [
+          "Gaming"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2728-7542-9726-3db4141869f9"
+      }
+    ]
+  },
+  "LockScreen": {
+    "Count": 14,
+    "Items": [
+      {
+        "Name": "Require digits in Windows Hello PIN",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/passportforwork-csp#devicetenantidpoliciespincomplexitydigits",
+        "ID": "019a8dfa-24bd-7860-a435-0e2d6ea2852d"
+      },
+      {
+        "Name": "Require lower case letters in Windows Hello PIN",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/passportforwork-csp#devicetenantidpoliciespincomplexitylowercaseletters",
+        "ID": "019a8dfa-24bd-751f-a0b4-46fdeb9c68d3"
+      },
+      {
+        "Name": "Set Expiration for Windows Hello PIN",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/passportforwork-csp#devicetenantidpoliciespincomplexityexpiration",
+        "ID": "019a8dfa-24bd-79fe-ad1a-adda5634bc7c"
+      },
+      {
+        "Name": "Save history of Windows Hello PIN",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/passportforwork-csp#devicetenantidpoliciespincomplexityhistory",
+        "ID": "019a8dfa-24bd-7d7b-bdd3-0dbd96fd6f45"
+      },
+      {
+        "Name": "Don't Display Network Selection UI on lock screen",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-windowslogon#dontdisplaynetworkselectionui",
+        "ID": "019a8dfa-24bd-7a41-b3c7-9a9c917dbf6d"
+      },
+      {
+        "Name": "Set the Machine inactivity limit policy so the device will automatically lock after 120 seconds of inactivity.",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/interactive-logon-machine-inactivity-limit",
+        "ID": "019a8dfa-24bd-7bb2-9fd0-65aa07ed0cf7"
+      },
+      {
+        "Name": "Set an Interactive logon policy to require CTRL+ALT+DEL key combination on Lock Screen before you can enter your credentials. This can mitigate certain attacks that utilize fake lock screens in order to capture the user credentials in clear text such as passwords.",
+        "Category": "LockScreen",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "LockScreen_RequireCTRLAltDel",
+        "SubCategoryName": "Require CTRL Alt Del",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/interactive-logon-do-not-require-ctrl-alt-del",
+        "ID": "019a8dfa-24be-7c7e-954a-1f6d256ef69b"
+      },
+      {
+        "Name": "Set an Interactive logon policy for Machine account lockout threshold so that the BitLocker encrypted device will be locked after 5 failed attempts to login. You will be required to enter BitLocker recovery key for the OS drive to login again.",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-24be-749c-a8b3-cbc794c0f4ff"
+      },
+      {
+        "Name": "Set an Interactive logon policy to stop displaying user information when the session is locked.",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-24be-77e9-bcd1-57f33d8aa05d"
+      },
+      {
+        "Name": "Set an Interactive logon policy to stop displaying the username at Lock Screen.",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/interactive-logon-dont-display-username-at-sign-in",
+        "ID": "019a8dfa-24be-7db6-988d-1d3a8871263f"
+      },
+      {
+        "Name": "Set an Interactive logon policy to stop displaying last signed-in details at Lock Screen.",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "LockScreen_NoLastSignedIn",
+        "SubCategoryName": "No Last Signed In",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/interactive-logon-do-not-display-last-user-name",
+        "ID": "019a8dfa-24be-7ee6-b9c1-745266806dce"
+      },
+      {
+        "Name": "Set the number of allowed failed sign-in attempts to 5. In combination with other policies in this category, this means every 5 failed sign-in attempts will need a full day to pass before 5 more attempts can be made, otherwise BitLocker will engage, the system will restart and 48-digit BitLocker code will be required. This policy greatly prevents brute force attempts.",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation",
+          "School"
+        ],
+        "URL": "https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/account-lockout-threshold",
+        "ID": "019a9053-c2ad-784a-a5f3-98833b9561ef"
+      },
+      {
+        "Name": "Set the account lockout duration to 1440 minutes or 1 day. In combination with other policies in this category, this means every 5 failed sign-in attempts will need a full day to pass before 5 more attempts can be made, otherwise BitLocker will engage, the system will restart and 48-digit BitLocker code will be required.",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation",
+          "School"
+        ],
+        "URL": "https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/reset-account-lockout-counter-after",
+        "ID": "019a9054-432d-78e3-84dd-643d9c6f32e5"
+      },
+      {
+        "Name": "Set the reset account lockout counter to 1440 minutes or 1 day.",
+        "Category": "LockScreen",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation",
+          "School"
+        ],
+        "URL": "https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/account-lockout-duration",
+        "ID": "019a9054-7174-7921-a470-8056254a15cf"
+      }
+    ]
+  },
+  "UserAccountControl": {
+    "Count": 6,
+    "Items": [
+      {
+        "Name": "Hide Fast User Switching entry points",
+        "Category": "UserAccountControl",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "UAC_NoFastUserSwitching",
+        "SubCategoryName": "No Fast User Switching",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-windowslogon#hidefastuserswitching",
+        "ID": "019a8dfa-277b-7ccf-a0d3-c7eaef14b258"
+      },
+      {
+        "Name": "Set the behavior of the elevation prompt for administrators in Admin Approval Mode: Prompt for Consent on the Secure Desktop",
+        "Category": "UserAccountControl",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/openspecs/windows_protocols/ms-gpsb/341747f5-6b5d-4d30-85fc-fa1cc04038d4",
+        "ID": "019a8dfa-277c-7722-8319-31aaa70845e5"
+      },
+      {
+        "Name": "Set the behavior of the elevation prompt for standard users: Prompt for Credentials on the Secure Desktop",
+        "Category": "UserAccountControl",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/openspecs/windows_protocols/ms-gpsb/15f4f7b3-d966-4ff4-8393-cb22ea1c3a63",
+        "ID": "019a8dfa-277c-7cbb-8d31-a9637b9ef898"
+      },
+      {
+        "Name": "Configure the system to only elevate executables that are signed and Validated. Any program that is unsigned or signed with self-signed certificates will not be able to run as administrator.",
+        "Category": "UserAccountControl",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "UAC_OnlyElevateSigned",
+        "SubCategoryName": "Only Elevate Signed",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/openspecs/windows_protocols/ms-gpsb/a9b816e0-075b-4674-a1a9-cecd1d9523e7",
+        "ID": "019a8dfa-277d-784d-bd53-44eeeffd4bc9"
+      },
+      {
+        "Name": "Set the behavior of the elevation prompt for administrators in Enhanced Privilege Protection Mode: Prompt for Credentials on the Secure Desktop",
+        "Category": "UserAccountControl",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-277d-7435-b9f4-c07249acd178"
+      },
+      {
+        "Name": "Administrator Protection: Set the type of Admin Approval Mode to be Admin Approval Mode with enhanced privilege protection",
+        "Category": "UserAccountControl",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://blogs.windows.com/windowsdeveloper/2025/05/19/enhance-your-application-security-with-administrator-protection/",
+        "ID": "019a8dfa-277e-72da-8a60-eb86938f9d88"
+      }
+    ]
+  },
+  "DeviceGuard": {
+    "Count": 10,
+    "Items": [
+      {
+        "Name": "Enable Virtualization Based Security",
+        "Category": "DeviceGuard",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-deviceguard?WT.mc_id=Portal-fx#enablevirtualizationbasedsecurity",
+        "ID": "019a8dfa-23ea-725f-bd56-4e950531e3be"
+      },
+      {
+        "Name": "Require Platform Security Features",
+        "Category": "DeviceGuard",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-deviceguard?WT.mc_id=Portal-fx#requireplatformsecurityfeatures",
+        "ID": "019a8dfa-23ea-72ce-bd09-c1449ceb9760"
+      },
+      {
+        "Name": "Hypervisor Enforced Code Integrity - UEFI Lock",
+        "Category": "DeviceGuard",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-VirtualizationBasedTechnology?WT.mc_id=Portal-fx#hypervisorenforcedcodeintegrity",
+        "ID": "019a8dfa-23eb-72a7-b7c8-300d431d1764"
+      },
+      {
+        "Name": "Require HVCI MAT (Memory Attribute Table)",
+        "Category": "DeviceGuard",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-VirtualizationBasedTechnology?WT.mc_id=Portal-fx#requireuefimemoryattributestable",
+        "ID": "019a8dfa-23eb-725c-ba52-1a60427c2cdb"
+      },
+      {
+        "Name": "Credential Guard Configuration - UEFI Lock",
+        "Category": "DeviceGuard",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-deviceguard?WT.mc_id=Portal-fx#lsacfgflags",
+        "ID": "019a8dfa-23eb-7e47-88bc-35a0b0de60b4"
+      },
+      {
+        "Name": "Configure Machine Identity Isolation Configuration",
+        "Category": "DeviceGuard",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-23eb-7979-9da3-570a9ca6ef80"
+      },
+      {
+        "Name": "Enable System Guard Secure Launch if hardware support exists",
+        "Category": "DeviceGuard",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-deviceguard?WT.mc_id=Portal-fx#configuresystemguardlaunch",
+        "ID": "019a8dfa-23ec-7473-a7d6-12adcc248de7"
+      },
+      {
+        "Name": "Configure Kernel Shadow Stacks Launch",
+        "Category": "DeviceGuard",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-23ec-7373-af59-6f30f347ac16"
+      },
+      {
+        "Name": "Enable Local Security Authority (LSA) process Protection with UEFI Lock",
+        "Category": "DeviceGuard",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-lsa#configurelsaprotectedprocess",
+        "ID": "019a8dfa-23ec-7e1d-961c-ac701dfa9f74"
+      },
+      {
+        "Name": "Enable VBS and Memory Integrity in Mandatory Mode",
+        "Category": "DeviceGuard",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "DeviceGuard_MandatoryModeForVBS",
+        "SubCategoryName": "Mandatory Mode For VBS",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/security/hardware-security/enable-virtualization-based-protection-of-code-integrity?tabs=reg",
+        "ID": "019a8dfa-23ed-7941-9ed8-f90fba3713bc"
+      }
+    ]
+  },
+  "WindowsFirewall": {
+    "Count": 21,
+    "Items": [
+      {
+        "Name": "Configure the Windows Firewall Policy Version",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fasp/1da2ee70-a6ae-4f76-b08f-fdc25c77d8a0#Appendix_A_12",
+        "ID": "019a8dfa-27dd-7774-9490-365b48bee4bf"
+      },
+      {
+        "Name": "Enable Windows Firewall for Domain profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoredomainprofileenablefirewall",
+        "ID": "019a8dfa-27dd-7692-984f-7419b42bd15f"
+      },
+      {
+        "Name": "Set Default Outbound Action for Domain profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoredomainprofiledefaultoutboundaction",
+        "ID": "019a8dfa-27dd-7360-acd1-93cf6ae6fee6"
+      },
+      {
+        "Name": "Set Default Inbound Action for Domain profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoredomainprofiledefaultinboundaction",
+        "ID": "019a8dfa-27dd-7841-b55b-367a435d31af"
+      },
+      {
+        "Name": "Display notifications for Domain profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoredomainprofiledisableinboundnotifications",
+        "ID": "019a8dfa-27de-70c1-b590-f2df35707200"
+      },
+      {
+        "Name": "Configure Log file path for domain profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoredomainprofilelogfilepath",
+        "ID": "019a8dfa-27de-7e3f-8a92-3e1921943b8d"
+      },
+      {
+        "Name": "Configure Log file size for domain profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoredomainprofilelogmaxfilesize",
+        "ID": "019a8dfa-27de-7f1c-8f29-a9c528f839d0"
+      },
+      {
+        "Name": "Log blocked connections for domain profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoredomainprofileenablelogdroppedpackets",
+        "ID": "019a8dfa-27de-7423-b787-157104704c2a"
+      },
+      {
+        "Name": "Log successful connections for domain profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoredomainprofileenablelogsuccessconnections",
+        "ID": "019a8dfa-27de-713d-bbe5-7cc6b582e016"
+      },
+      {
+        "Name": "Enable Windows Firewall for Private profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoreprivateprofileenablefirewall",
+        "ID": "019a8dfa-27de-7070-a8e7-b0aa8b48be21"
+      },
+      {
+        "Name": "Display notifications for Private profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoreprivateprofiledisableinboundnotifications",
+        "ID": "019a8dfa-27de-7ba5-9306-7fd6c21bfd99"
+      },
+      {
+        "Name": "Configure Log file size for Private profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoreprivateprofilelogmaxfilesize",
+        "ID": "019a8dfa-27de-7604-a590-0ef7459d5d39"
+      },
+      {
+        "Name": "Log blocked connections for Private profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoreprivateprofileenablelogdroppedpackets",
+        "ID": "019a8dfa-27de-7479-9335-409b26dfccca"
+      },
+      {
+        "Name": "Configure Log file path for Private profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstoreprivateprofilelogfilepath",
+        "ID": "019a8dfa-27df-7c18-a53f-97de51b585d3"
+      },
+      {
+        "Name": "Enable Windows Firewall for Public profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstorepublicprofileenablefirewall",
+        "ID": "019a8dfa-27df-7489-a762-b2af66df4468"
+      },
+      {
+        "Name": "Display notifications for Public profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstorepublicprofiledisableinboundnotifications",
+        "ID": "019a8dfa-27df-711c-a39f-d676202ebcc8"
+      },
+      {
+        "Name": "Configure Log file size for Public profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstorepublicprofilelogmaxfilesize",
+        "ID": "019a8dfa-27e1-78fd-a45a-f4d0f4bc3e5d"
+      },
+      {
+        "Name": "Log blocked connections for Public profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstorepublicprofileenablelogdroppedpackets",
+        "ID": "019a8dfa-27e1-7756-b7c9-458d585d3c50"
+      },
+      {
+        "Name": "Configure Log file path for Public profile",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/firewall-csp#mdmstorepublicprofilelogfilepath",
+        "ID": "019a8dfa-27e2-71d5-8e62-e37c3b5ad3e4"
+      },
+      {
+        "Name": "Disable mDNS UDP-In Firewall Rules. It adds an extra measure of security in public places, like a coffee shop but might interfere with Miracast screen sharing, which relies on the Public profile or home networks where the Private profile is not selected.",
+        "Category": "WindowsFirewall",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://techcommunity.microsoft.com/t5/networking-blog/mdns-in-the-enterprise/ba-p/3275777",
+        "ID": "019abc74-7e26-7825-b763-6a7577ee5d87"
+      },
+      {
+        "Name": "Set the Network Location of all connections to Public. Public network means less trust to other network devices.",
+        "Category": "WindowsFirewall",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://support.microsoft.com/en-us/windows/make-a-wi-fi-network-public-or-private-in-windows-0460117d-8d3e-a7ac-f003-7a0da607448d",
+        "ID": "019abec8-2702-7fa7-9db2-404dd3647126"
+      }
+    ]
+  },
+  "WindowsNetworking": {
+    "Count": 20,
+    "Items": [
+      {
+        "Name": "Set the minimum SMB server version",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2838-70f3-b2b9-2022fd28ccbd"
+      },
+      {
+        "Name": "Enable SMB Server Over QUIC",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2838-7770-9e68-58b494f76645"
+      },
+      {
+        "Name": "Configure secure SMB Server Cipher Suite Order",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-lanmanserver#pol_ciphersuiteorder",
+        "ID": "019a8dfa-2838-7515-a455-fff3c68e6ceb"
+      },
+      {
+        "Name": "Require encryption for SMB client",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2838-79bd-8f7c-cc134541fc63"
+      },
+      {
+        "Name": "Set the minimum SMB client version",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2838-77a5-bc70-c5a0cbe581f5"
+      },
+      {
+        "Name": "Configure secure SMB Client Cipher Suite Order",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-lanmanworkstation#pol_ciphersuiteorder",
+        "ID": "019a8dfa-2838-7e64-964d-666ef51e1c60"
+      },
+      {
+        "Name": "Enable SMB Client Over QUIC",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2838-71f6-910c-c9b052553bc6"
+      },
+      {
+        "Name": "Disable NetBIOS",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2838-75be-9700-902625f190ed"
+      },
+      {
+        "Name": "Disable Smart Name Resolution",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-dnsclient#dns_smartmultihomednameresolution",
+        "ID": "019a8dfa-2839-75ca-9507-bce49b534f97"
+      },
+      {
+        "Name": "Disable Multicast",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-dnsclient#turn_off_multicast",
+        "ID": "019a8dfa-2839-7e05-9ede-cb97f86a90a7"
+      },
+      {
+        "Name": "Disable HTTP Printing",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-connectivity?WT.mc_id=Portal-fx#diableprintingoverhttp",
+        "ID": "019a8dfa-2839-7173-9e7c-80c74cfb465b"
+      },
+      {
+        "Name": "Disable Web PnP Download",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-icm#disablewebpnpdownload_1",
+        "ID": "019a8dfa-2839-76e2-8581-2164d2c34192"
+      },
+      {
+        "Name": "Block NTLM for SMB",
+        "Category": "WindowsNetworking",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "WindowsNetworking_BlockNTLM",
+        "SubCategoryName": "Block NTLM",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2839-7660-bb0c-efae9bb797e7"
+      },
+      {
+        "Name": "Disable RPC Endpoint Mapper Client Authentication",
+        "Category": "WindowsNetworking",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "WindowsNetworking_BlockNTLM",
+        "SubCategoryName": "Block NTLM",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-remoteprocedurecall#rpcendpointmapperclientauthentication",
+        "ID": "019a8dfa-2839-7430-a4e4-570f2666d608"
+      },
+      {
+        "Name": "Enable SMB Server Encryption",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2839-7e63-b0d8-91ac94981b2e"
+      },
+      {
+        "Name": "Disable LMHOSTS lookup protocol on all network adapters",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2839-7c85-8e9c-7d487469a2e6"
+      },
+      {
+        "Name": "Remove remotely accessible registry paths.",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2839-7a9a-a137-dbcfe23f8f33"
+      },
+      {
+        "Name": "Remove remotely accessible registry paths and subpaths.",
+        "Category": "WindowsNetworking",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-283a-7f1c-b135-3df7524fb167"
+      },
+      {
+        "Name": "Deny incoming NTLM connections for all accounts.",
+        "Category": "WindowsNetworking",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "WindowsNetworking_BlockNTLM",
+        "SubCategoryName": "Block NTLM",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-283a-72f5-828e-a8d8c69b2528"
+      },
+      {
+        "Name": "Deny outgoing NTLM connections.",
+        "Category": "WindowsNetworking",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "WindowsNetworking_BlockNTLM",
+        "SubCategoryName": "Block NTLM",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-283a-7c6b-a9ec-75a2f2ad89d8"
+      }
+    ]
+  },
+  "MiscellaneousConfigurations": {
+    "Count": 39,
+    "Items": [
+      {
+        "Name": "Create custom views in the Windows Event Viewer for easy access to important security events.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "ID": "019a905d-98d7-78ab-9064-4c5059f0b364"
+      },
+      {
+        "Name": "Configure the SSH client's configurations to use secure MACs (Message Authentication Codes).",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation",
+          "School",
+          "Business"
+        ],
+        "URL": "https://learn.microsoft.com/windows-server/administration/OpenSSH/openssh-server-configuration#openssh-configuration-files",
+        "ID": "019a905d-f082-7fae-853e-ad55a6c74f9a"
+      },
+      {
+        "Name": "Enable auditing and tracking Lock Screen locks and unlocks.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation",
+          "School",
+          "Business"
+        ],
+        "ID": "019a905e-7470-7be4-94d6-4cef2cd243df"
+      },
+      {
+        "Name": "Display the file extension for (.url) files in the File Explorer. Prevents internet shortcuts from masquerading as legitimate files. This mitigates security risks where attackers use hidden extensions to disguise phishing links or malicious redirects as safe documents.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2016-3353",
+        "ID": "019b2d4b-8bdc-78cc-afd2-02f21007f008"
+      },
+      {
+        "Name": "Display the file extension for shortcut (.lnk) files in the File Explorer. Attackers frequently rely on the default hidden state of shortcuts to disguise malicious payloads as harmless documents. Revealing the extension allows you to verify the true file type and identify deceptive shortcuts before execution.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://www.microsoft.com/en-us/security/blog/2022/10/27/raspberry-robin-worm-part-of-larger-ecosystem-facilitating-pre-ransomware-activity/",
+        "ID": "019b2d4b-57e2-79e4-9a23-6515027b353c"
+      },
+      {
+        "Name": "Display the file extension for (.pif) files in the File Explorer. Program Information Files (PIF) function similarly to .exe files and are frequently used by attackers to hide malware behind a less familiar file type.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "ID": "019b2d62-724c-7a01-a037-050d83b74faf"
+      },
+      {
+        "Name": "Disabling the WebClient service prevents attackers from abusing WebDAV to intercept and steal NTLM credentials and other sensitive data via malicious links.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://techcommunity.microsoft.com/blog/itopstalkblog/how-to-defend-users-from-interception-attacks-via-smb-client-defense/1494995",
+        "ID": "019d4495-d6ae-76ab-9ea0-f7db73972ed0"
+      },
+      {
+        "Name": "Include command line in process creation events",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-auditsettings#includecmdline",
+        "ID": "019a8dfa-25d8-7123-9d2a-7460ac2a826e"
+      },
+      {
+        "Name": "Request claims and compound authentication for DAC and Kerberos armoring",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-kerberos#kerberosclientsupportsclaimscompoundarmor",
+        "ID": "019a8dfa-25d8-7918-a4eb-b6906fed718d"
+      },
+      {
+        "Name": "Disable Location",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-System?WT.mc_id=Portal-fx#allowlocation",
+        "ID": "019a8dfa-25d9-76ad-bf84-a9957a579037"
+      },
+      {
+        "Name": "Disable Location Scripting",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Gaming",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-sensors#disablelocationscripting_2",
+        "ID": "019a8dfa-25d9-70e2-8c42-641d0072de8a"
+      },
+      {
+        "Name": "Disable Windows Location Provider",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Gaming",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-locationprovideradm#disablewindowslocationprovider_1",
+        "ID": "019a8dfa-25d9-7b66-ba7d-ccca946a0987"
+      },
+      {
+        "Name": "Enable Svchost Mitigation",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Gaming",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-servicecontrolmanager#svchostprocessmitigation",
+        "ID": "019a8dfa-25d9-7f7f-be0f-30dc1e6ea5c2"
+      },
+      {
+        "Name": "Boot-Start Driver Initialization Policy set to Good only",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_DriverLoadPolicyGoodOnly",
+        "SubCategoryName": "Driver Load Policy Good Only",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-system#bootstartdriverinitialization",
+        "ID": "019a8dfa-25d9-715e-8ffb-b201a32df5da"
+      },
+      {
+        "Name": "Enable support for long paths",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_EnableLongPathSupport",
+        "SubCategoryName": "Enable Long Path Support",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation",
+        "ID": "019a8dfa-25da-7271-a240-3d96a8274067"
+      },
+      {
+        "Name": "Enable Windows Protected Print",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategory": "MiscellaneousConfigurations_EnableWindowsProtectedPrint",
+        "SubCategoryName": "Enable Windows Protected Print",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-printers#configurewindowsprotectedprint",
+        "ID": "019a8dfa-25da-7c9a-87e2-07fa9df81fff"
+      },
+      {
+        "Name": "Disable Online Tips.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-settings#allowonlinetips",
+        "ID": "019a8dfa-25da-7b1b-b3b6-32a357ccf33a"
+      },
+      {
+        "Name": "Disable Find My Device feature.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-experience#allowfindmydevice",
+        "ID": "019a8dfa-25da-7b65-98af-e227ed371206"
+      },
+      {
+        "Name": "Disable Automatic Update of Speech Data.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-speech#allowspeechmodelupdate",
+        "ID": "019a8dfa-25da-7981-b771-238cea55ec4e"
+      },
+      {
+        "Name": "Turn off the advertising ID, preventing apps from using the ID for experiences across apps.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-privacy#disableadvertisingid",
+        "ID": "019a8dfa-25da-76d1-a845-9d08e5abfa50"
+      },
+      {
+        "Name": "Turn off Get tips and suggestions when using Windows.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-experience#allowwindowstips",
+        "ID": "019a8dfa-25da-716d-a22f-042103565ddd"
+      },
+      {
+        "Name": "Turn off cloud optimized content in all Windows experiences.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-experience#disablecloudoptimizedcontent",
+        "ID": "019a8dfa-25da-7ce5-9464-dbad3653b273"
+      },
+      {
+        "Name": "Do not show feedback notifications.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-experience#donotshowfeedbacknotifications",
+        "ID": "019a8dfa-25da-7022-a696-6ff226cd5782"
+      },
+      {
+        "Name": "Turn off Automatic Download and Update of Map Data.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-maps#enableofflinemapsautoupdate",
+        "ID": "019a8dfa-25db-79e0-85c3-6a74cef4e367"
+      },
+      {
+        "Name": "Disable Message Service Cloud Sync for cellular text messages.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-messaging#allowmessagesync",
+        "ID": "019a8dfa-25db-78be-8d69-6e3db201956e"
+      },
+      {
+        "Name": "Block Windows from downloading Fonts Catalog.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-system#allowfontproviders",
+        "ID": "019a8dfa-25db-7467-bf85-fdc34ba8a6e7"
+      },
+      {
+        "Name": "Disable \"Continue experiences on this device\" feature.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-admx-grouppolicy#enablecdp",
+        "ID": "019a8dfa-25db-7a68-a0b7-7c19deb28c03"
+      },
+      {
+        "Name": "Disable support for web-to-app linking with app URI handlers.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-applicationdefaults#enableappurihandlers",
+        "ID": "019a8dfa-25db-7c2f-a545-64267fbe331d"
+      },
+      {
+        "Name": "Don't search the web or display web results in Search.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-search#donotusewebresults",
+        "ID": "019a8dfa-25db-77a3-bd72-896b18ac25cc"
+      },
+      {
+        "Name": "Do not allow web search.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ReducedTelemetry",
+        "SubCategoryName": "Reduced Telemetry",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/privacy/manage-connections-from-windows-operating-system-components-to-microsoft-services#21-cortana-and-search-group-policies",
+        "ID": "019a8dfa-25db-7f47-8a1f-2bb828b51c97"
+      },
+      {
+        "Name": "Enable enhanced search in Windows",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-25db-7ef4-88e8-b2bf67d1b302"
+      },
+      {
+        "Name": "Set Microsoft Edge (Stable) to update over Metered connections",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-25db-777d-bc61-7ab19ad0b951"
+      },
+      {
+        "Name": "Set Microsoft Edge (Beta) to update over Metered connections",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-25dc-7696-a055-cd80ec0e2581"
+      },
+      {
+        "Name": "Set Microsoft Edge (Dev) to update over Metered connections",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-25dc-7ced-a50d-35a63912e0cd"
+      },
+      {
+        "Name": "Implement WinVerifyTrust Signature Validation part 1",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-25dc-7e4a-b5da-5998e127919b"
+      },
+      {
+        "Name": "Implement WinVerifyTrust Signature Validation part 2",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-25dc-7279-b9c5-4a547cb79a4d"
+      },
+      {
+        "Name": "Force strong key protection for user keys stored on the computer. You will be able to securely save private keys of the certificates you install on the computer and the same credentials will be required when accessing the private key such as for signing operations.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategory": "MiscellaneousConfigurations_ForceStrongKeyProtection",
+        "SubCategoryName": "Force Strong Key Protection",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-25dc-7f42-8129-f54fabf027e5"
+      },
+      {
+        "Name": "Boot-Start Driver Initialization Policy set to Good and Unknown",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-system#bootstartdriverinitialization",
+        "ID": "019b0786-b318-7ee2-88a0-bdfafe8a0261"
+      },
+      {
+        "Name": "Configure the Antimalware Scan Interface (AMSI) to strictly enforce Authenticode code signing requirements for all third-party antimalware providers.",
+        "Category": "MiscellaneousConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/win32/api/amsi/nn-amsi-iantimalwareprovider#remarks",
+        "ID": "019b4f4e-256f-73e9-8015-45896cac9a0a"
+      }
+    ]
+  },
+  "WindowsUpdateConfigurations": {
+    "Count": 22,
+    "Items": [
+      {
+        "Name": "Allow updates to be downloaded automatically over metered connections",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#allowautowindowsupdatedownloadovermeterednetwork",
+        "ID": "019a8dfa-2890-7672-b793-c2065ea04316"
+      },
+      {
+        "Name": "Enable features introduced via servicing that are off by default",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#allowtemporaryenterprisefeaturecontrol",
+        "ID": "019a8dfa-2890-72bc-be06-c255915c4e8b"
+      },
+      {
+        "Name": "Set compliance deadline for feature updates.",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2891-735a-a264-fdc3901f163a"
+      },
+      {
+        "Name": "Number of days before feature updates are installed on devices automatically",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#configuredeadlineforfeatureupdates",
+        "ID": "019a8dfa-2892-7f37-a01e-ce55a2af6845"
+      },
+      {
+        "Name": "Number of grace period days before feature updates are installed on devices automatically",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#configuredeadlinegraceperiodforfeatureupdates",
+        "ID": "019a8dfa-2892-7134-a621-afa65efaedd6"
+      },
+      {
+        "Name": "Specify the number of days before feature updates are installed on devices automatically",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#configuredeadlinenoautorebootforfeatureupdates",
+        "ID": "019a8dfa-2893-7326-a968-ed9bd488cac5"
+      },
+      {
+        "Name": "Set compliance deadline for quality updates.",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2893-75c2-a0b9-947671c9f801"
+      },
+      {
+        "Name": "Number of days before quality updates are installed on devices automatically",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#configuredeadlineforqualityupdates",
+        "ID": "019a8dfa-2898-7729-903f-0573705305b3"
+      },
+      {
+        "Name": "Number of grace period days before quality updates are installed on devices automatically",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#configuredeadlinegraceperiod",
+        "ID": "019a8dfa-2898-78d3-a439-6ee465905b4b"
+      },
+      {
+        "Name": "Specify the number of days before quality updates are installed on devices automatically",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#configuredeadlinenoautorebootforqualityupdates",
+        "ID": "019a8dfa-2899-7509-b458-47f923eb30d6"
+      },
+      {
+        "Name": "Set the computer to receive security updates and other important downloads through Windows Update",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/deployment/update/waas-wu-settings#configuring-automatic-updates-by-editing-the-registry",
+        "ID": "019a8dfa-2899-713e-8585-ca7e58ceb7dc"
+      },
+      {
+        "Name": "Automatically download updates and install them on maintenance day",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#allowautoupdate",
+        "ID": "019a8dfa-2899-7675-bf28-ba259c991c1b"
+      },
+      {
+        "Name": "Install updates during automatic maintenance",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-2899-7674-afe4-3bef1552bed7"
+      },
+      {
+        "Name": "Set scheduled install day to every day",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#scheduledinstallday",
+        "ID": "019a8dfa-2899-7713-a6e6-2925a0826a58"
+      },
+      {
+        "Name": "Set scheduled install time to any time",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#scheduledinstalltime",
+        "ID": "019a8dfa-289a-75de-8f81-975c8a132a55"
+      },
+      {
+        "Name": "Remove scheduling for installing updates only on specific weeks.",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#scheduledinstalleveryweek",
+        "ID": "019a8dfa-289a-7ce2-bace-c9d1b97842f6"
+      },
+      {
+        "Name": "Remove scheduling for installing updates only on specific weeks.",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#scheduledinstallfirstweek",
+        "ID": "019a8dfa-289a-7a60-8011-3540c9711552"
+      },
+      {
+        "Name": "Remove scheduling for installing updates only on specific weeks.",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#scheduledinstallsecondweek",
+        "ID": "019a8dfa-289a-7de9-bb9e-904fab25f81f"
+      },
+      {
+        "Name": "Remove scheduling for installing updates only on specific weeks.",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#scheduledinstallthirdweek",
+        "ID": "019a8dfa-289a-7ec2-b9ca-7b850fe4ba4a"
+      },
+      {
+        "Name": "Remove scheduling for installing updates only on specific weeks.",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-update#scheduledinstallfourthweek",
+        "ID": "019a8dfa-289b-7a85-b305-db15a70ab02b"
+      },
+      {
+        "Name": "Install updates for other Microsoft products",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-Update?WT.mc_id=Portal-fx#allowmuupdateservice",
+        "ID": "019a8dfa-289c-77aa-884f-5228f58044bf"
+      },
+      {
+        "Name": "Enable restart notification for Windows update",
+        "Category": "WindowsUpdateConfigurations",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-289c-70b1-bbdb-db188f905f2e"
+      }
+    ]
+  },
+  "EdgeBrowserConfigurations": {
+    "Count": 16,
+    "Items": [
+      {
+        "Name": "Recommends to block 3rd party cookies",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245c-7915-80a8-42e06eb15599"
+      },
+      {
+        "Name": "Sets Edge to use system's DNS over HTTPS. This makes MDAG to work properly too",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245d-70b5-b821-46edb81a7afd"
+      },
+      {
+        "Name": "Enable Encrypted Client Hello",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245d-7870-a90c-8b9e89bede12"
+      },
+      {
+        "Name": "Block Basic authentication for HTTP",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245d-7cd6-bb97-2d07cb3b4d9b"
+      },
+      {
+        "Name": "Allow devices using the Edge category protection to receive new features and experimentations like normal devices",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245d-7adf-90ec-8be2fc3205a8"
+      },
+      {
+        "Name": "Enforces the audio process to run sandboxed",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245e-7e24-ba82-cab3ba9957df"
+      },
+      {
+        "Name": "Recommends that the share additional operating system region setting to be set to never.",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245e-7ebe-b8c9-84a2aa63fa7e"
+      },
+      {
+        "Name": "Disable TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA - (CBC - SHA1)",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245e-72fe-bdc3-b344f1830eb9"
+      },
+      {
+        "Name": "Disable TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA - (CBC - SHA1)",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245e-71f0-a20f-07a85b192eb3"
+      },
+      {
+        "Name": "Disable TLS_RSA_WITH_AES_256_CBC_SHA - (NO PFS - CBC - SHA1)",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245e-7d3e-9bec-fcfd217fdc9e"
+      },
+      {
+        "Name": "Disable TLS_RSA_WITH_AES_128_CBC_SHA - (NO PFS - CBC - SHA1)",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245f-721b-8ac9-5d8b3e511cba"
+      },
+      {
+        "Name": "Disable TLS_RSA_WITH_AES_128_GCM_SHA256 - (NO PFS)",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245f-7942-a7bc-e23b734b1818"
+      },
+      {
+        "Name": "Disable TLS_RSA_WITH_AES_256_GCM_SHA384 - (NO PFS)",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245f-7277-bba9-451f218089da"
+      },
+      {
+        "Name": "Never let websites ask to access local USB connected devices",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245f-7f71-ac20-65ce6c7a2658"
+      },
+      {
+        "Name": "Denies the Window Management permission on all sites by default",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Business",
+          "SpecializedAccessWorkstation",
+          "PrivilegedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-245f-7346-b42e-c77f0f111436"
+      },
+      {
+        "Name": "Prevent the browser process from creating dynamic code",
+        "Category": "EdgeBrowserConfigurations",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/deployedge/configure-edge-with-mdm",
+        "ID": "019a8dfa-2460-70c9-8579-bfcf1b4a6122"
+      }
+    ]
+  },
+  "NonAdminCommands": {
+    "Count": 9,
+    "Items": [
+      {
+        "Name": "Enable showing File extensions in File Explorer",
+        "Category": "NonAdminCommands",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/openspecs/windows_protocols/ms-gppref/3c837e92-016e-4148-86e5-b4f0381a757f",
+        "ID": "019a8dfa-26df-7083-ba8d-99ca9fbc4daa"
+      },
+      {
+        "Name": "Enable showing hidden files in File Explorer",
+        "Category": "NonAdminCommands",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-26df-7d49-a993-76d0578a1875"
+      },
+      {
+        "Name": "Disable websites from accessing local language list",
+        "Category": "NonAdminCommands",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-26df-742b-8086-c962eea4bbb5"
+      },
+      {
+        "Name": "Turn off safe search in Windows search",
+        "Category": "NonAdminCommands",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-26df-7a28-b9d5-cd82648a1ffc"
+      },
+      {
+        "Name": "Turn on Show text suggestions when typing on the physical keyboard",
+        "Category": "NonAdminCommands",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/apps/develop/settings/settings-windows-11#typing",
+        "ID": "019a8dfa-26e0-7502-9bfa-c3be4370b067"
+      },
+      {
+        "Name": "Turn on Multilingual text suggestions",
+        "Category": "NonAdminCommands",
+        "IsApplied": false,
+        "StatusState": "NotApplied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/windows/apps/develop/settings/settings-windows-11#registry-values-under-hkcusoftwaremicrosoftinputsettings",
+        "ID": "019a8dfa-26e0-7c47-8d35-d41fc189a1f8"
+      },
+      {
+        "Name": "Turn off sticky key shortcut of pressing shift key 5 time fast",
+        "Category": "NonAdminCommands",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-26e0-77bd-886f-8ff65cd1b994"
+      },
+      {
+        "Name": "Disables show reminders and incoming VoIP calls on the lock screen",
+        "Category": "NonAdminCommands",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-26e0-759b-a267-75ee66182fb9"
+      },
+      {
+        "Name": "Enable Clipboard History",
+        "Category": "NonAdminCommands",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-26e0-704f-9f30-389a36c9fe7b"
+      }
+    ]
+  },
+  "MSFTSecBaselines_OptionalOverrides": {
+    "Count": 17,
+    "Items": [
+      {
+        "Name": "Apply UAC restrictions to local accounts on network logons",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "All"
+        ],
+        "URL": "https://learn.microsoft.com/troubleshoot/windows-server/windows-security/user-account-control-and-remote-restriction#how-to-disable-uac-remote-restrictions",
+        "ID": "019a8dfa-263a-7ea5-862e-ab88fe751f03"
+      },
+      {
+        "Name": "Let the OS use BitLocker encrypted drives created in other organizations.",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263a-7dce-8db0-825374c6d2a1"
+      },
+      {
+        "Name": "Do not turn off experiences that help consumers make the most of their devices and Microsoft account.",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-experience#allowwindowsconsumerfeatures",
+        "ID": "019a8dfa-263b-716e-bc14-4b50f9fea225"
+      },
+      {
+        "Name": "Allow Game DVR feature to be used.",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263b-7157-89d0-5af8eb4e23e1"
+      },
+      {
+        "Name": "Enable Internet Connection Sharing (ICS) user interface for the local Admin.",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263b-7dc1-bfa1-e9dca92654a6"
+      },
+      {
+        "Name": "Allow users to use Sudo feature.",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263b-762c-adf8-c61bb9a44ad1"
+      },
+      {
+        "Name": "Do not hide exclusions in the Microsoft Defender from the local Admins.",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/defender-csp#configurationhideexclusionsfromlocaladmins",
+        "ID": "019a8dfa-263b-79e9-a3e3-60ee6d4f9baf"
+      },
+      {
+        "Name": "Allow drive mapping in Remote Desktop Sessions and Hyper-V",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming"
+        ],
+        "URL": "https://learn.microsoft.com/windows/client-management/mdm/policy-csp-remotedesktopservices#donotallowdriveredirection",
+        "ID": "019a8dfa-263b-7015-b548-7c6e09f9f18d"
+      },
+      {
+        "Name": "Allow Clipboard sharing in Remote Desktop Sessions and Hyper-V",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263c-7c13-8f9f-891bb551f7ce"
+      },
+      {
+        "Name": "Configure Windows Firewall policy version",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business"
+        ],
+        "URL": "https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fasp/1da2ee70-a6ae-4f76-b08f-fdc25c77d8a0#Appendix_A_12",
+        "ID": "019a8dfa-263c-7921-a187-7a1c8b8a4f18"
+      },
+      {
+        "Name": "Do not disable notifications in the Windows Firewall for Private Profile",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263c-7aa5-8c02-b2003604f7da"
+      },
+      {
+        "Name": "Allow Windows Firewall policies defined in Windows Firewall advanced settings section to be used instead of only enforcing those defined in Group Policy.",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263c-7cb4-8ffa-3c36cf8cc2c5"
+      },
+      {
+        "Name": "Allow Windows Firewall IPSec policies defined in Windows Firewall advanced settings section to be used instead of only enforcing those defined in Group Policy.",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263c-706c-8b5a-4b5989db8a88"
+      },
+      {
+        "Name": "Do not disable notifications in the Windows Firewall for Public Profile",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263d-7737-8d92-29a17dfe3cf9"
+      },
+      {
+        "Name": "Let the OS write to removable drives not encrypted by BitLocker",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation"
+        ],
+        "URL": "",
+        "ID": "019a8dfa-263d-78f4-bf2d-7ea336aac7a0"
+      },
+      {
+        "Name": "Set the behavior of the elevation prompt for standard users: Prompt for Credentials on the Secure Desktop",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School",
+          "Business",
+          "SpecializedAccessWorkstation"
+        ],
+        "URL": "https://learn.microsoft.com/openspecs/windows_protocols/ms-gpsb/15f4f7b3-d966-4ff4-8393-cb22ea1c3a63",
+        "ID": "019b09c1-e25c-7d4f-9d03-afdcec167870"
+      },
+      {
+        "Name": "Allow signing in through Remote Desktop Services. This will allow you to use Remote Desktop (RDP) locally to sign into your machine.",
+        "Category": "MSFTSecBaselines_OptionalOverrides",
+        "IsApplied": true,
+        "StatusState": "Applied",
+        "SubCategoryName": "",
+        "DeviceIntents": [
+          "Development",
+          "Gaming",
+          "School"
+        ],
+        "URL": "https://learn.microsoft.com/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/deny-log-on-through-remote-desktop-services",
+        "ID": "019b2afa-abd8-7b8f-8136-de0baf0d50fc"
+      }
+    ]
+  },
+  "CryptographicBillOfMaterial": {
+    "BomFormat": "CBOM",
+    "SpecVersion": "1.0",
+    "Metadata": {
+      "Timestamp": "2026-04-11T16:48:20Z",
+      "Host": {
+        "Machine": "NASSIR-YOGA-26",
+        "OsVersion": "Microsoft Windows 10.0.26100",
+        "Architecture": "Arm64",
+        "IsFIPSPolicyEnabled": false
+      },
+      "Tool": {
+        "Name": "Harden System Security Application",
+        "Website": "https://github.com/HotCakeX/Harden-Windows-Security",
+        "Version": "1.0.49.0"
+      }
+    },
+    "Algorithms": [
+      {
+        "Name": "AES",
+        "OperationClass": 1,
+        "Flags": 0,
+        "AlgorithmType": "Cipher",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "3DES",
+        "OperationClass": 1,
+        "Flags": 0,
+        "AlgorithmType": "Cipher",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "3DES_112",
+        "OperationClass": 1,
+        "Flags": 0,
+        "AlgorithmType": "Cipher",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "XTS-AES",
+        "OperationClass": 1,
+        "Flags": 0,
+        "AlgorithmType": "Cipher",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "DESX",
+        "OperationClass": 1,
+        "Flags": 0,
+        "AlgorithmType": "Cipher",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "DES",
+        "OperationClass": 1,
+        "Flags": 0,
+        "AlgorithmType": "Cipher",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "RC2",
+        "OperationClass": 1,
+        "Flags": 0,
+        "AlgorithmType": "Cipher",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "RC4",
+        "OperationClass": 1,
+        "Flags": 0,
+        "AlgorithmType": "Cipher",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "CHACHA20_POLY1305",
+        "OperationClass": 1,
+        "Flags": 0,
+        "AlgorithmType": "Cipher",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SHA256",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SHA384",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SHA512",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SHA3-256",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SHA3-384",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SHA3-512",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "CSHAKE128",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "CSHAKE256",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "KMAC128",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "KMAC256",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SHAKE128",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SHAKE256",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SHA1",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "MD5",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "MD4",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "MD2",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "AES-GMAC",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "AES-CMAC",
+        "OperationClass": 2,
+        "Flags": 0,
+        "AlgorithmType": "Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "RSA",
+        "OperationClass": 3,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Hash",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "DH",
+        "OperationClass": 4,
+        "Flags": 0,
+        "AlgorithmType": "Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "ECDH_P256",
+        "OperationClass": 4,
+        "Flags": 0,
+        "AlgorithmType": "Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "ECDH_P384",
+        "OperationClass": 4,
+        "Flags": 0,
+        "AlgorithmType": "Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "ECDH_P521",
+        "OperationClass": 4,
+        "Flags": 0,
+        "AlgorithmType": "Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "ECDH",
+        "OperationClass": 4,
+        "Flags": 0,
+        "AlgorithmType": "Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "RSA_SIGN",
+        "OperationClass": 5,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "ECDSA_P256",
+        "OperationClass": 5,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "ECDSA_P384",
+        "OperationClass": 5,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "ECDSA_P521",
+        "OperationClass": 5,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "ECDSA",
+        "OperationClass": 5,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "DSA",
+        "OperationClass": 5,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "ML-DSA",
+        "OperationClass": 5,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": true,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "RNG",
+        "OperationClass": 6,
+        "Flags": 0,
+        "AlgorithmType": "Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "FIPS186DSARNG",
+        "OperationClass": 6,
+        "Flags": 0,
+        "AlgorithmType": "Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "DUALECRNG",
+        "OperationClass": 6,
+        "Flags": 0,
+        "AlgorithmType": "Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SP800_108_CTR_HMAC",
+        "OperationClass": 7,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "SP800_56A_CONCAT",
+        "OperationClass": 7,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "PBKDF2",
+        "OperationClass": 7,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "CAPI_KDF",
+        "OperationClass": 7,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "TLS1_1_KDF",
+        "OperationClass": 7,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "TLS1_2_KDF",
+        "OperationClass": 7,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      },
+      {
+        "Name": "HKDF",
+        "OperationClass": 7,
+        "Flags": 0,
+        "AlgorithmType": "Cipher, Hash, Asymmetric Encryption",
+        "IsOpenable": true,
+        "IsPostQuantum": false,
+        "SupportsKeyGeneration": false,
+        "SupportedParameterSets": []
+      }
+    ],
+    "CngCurves": [
+      {
+        "Name": "brainpoolP160r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.1",
+        "PublicKeyLengthBits": 160
+      },
+      {
+        "Name": "brainpoolP160t1",
+        "Oid": "1.3.36.3.3.2.8.1.1.2",
+        "PublicKeyLengthBits": 160
+      },
+      {
+        "Name": "brainpoolP192r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.3",
+        "PublicKeyLengthBits": 192
+      },
+      {
+        "Name": "brainpoolP192t1",
+        "Oid": "1.3.36.3.3.2.8.1.1.4",
+        "PublicKeyLengthBits": 192
+      },
+      {
+        "Name": "brainpoolP224r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.5",
+        "PublicKeyLengthBits": 224
+      },
+      {
+        "Name": "brainpoolP224t1",
+        "Oid": "1.3.36.3.3.2.8.1.1.6",
+        "PublicKeyLengthBits": 224
+      },
+      {
+        "Name": "brainpoolP256r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.7",
+        "PublicKeyLengthBits": 256
+      },
+      {
+        "Name": "brainpoolP256t1",
+        "Oid": "1.3.36.3.3.2.8.1.1.8",
+        "PublicKeyLengthBits": 256
+      },
+      {
+        "Name": "brainpoolP320r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.9",
+        "PublicKeyLengthBits": 320
+      },
+      {
+        "Name": "brainpoolP320t1",
+        "Oid": "1.3.36.3.3.2.8.1.1.10",
+        "PublicKeyLengthBits": 320
+      },
+      {
+        "Name": "brainpoolP384r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.11",
+        "PublicKeyLengthBits": 384
+      },
+      {
+        "Name": "brainpoolP384t1",
+        "Oid": "1.3.36.3.3.2.8.1.1.12",
+        "PublicKeyLengthBits": 384
+      },
+      {
+        "Name": "brainpoolP512r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.13",
+        "PublicKeyLengthBits": 512
+      },
+      {
+        "Name": "brainpoolP512t1",
+        "Oid": "1.3.36.3.3.2.8.1.1.14",
+        "PublicKeyLengthBits": 512
+      },
+      {
+        "Name": "curve25519",
+        "Oid": "",
+        "PublicKeyLengthBits": 255
+      },
+      {
+        "Name": "ec192wapi",
+        "Oid": "1.2.156.11235.1.1.2.1",
+        "PublicKeyLengthBits": 192
+      },
+      {
+        "Name": "nistP192",
+        "Oid": "1.2.840.10045.3.1.1",
+        "PublicKeyLengthBits": 192
+      },
+      {
+        "Name": "nistP224",
+        "Oid": "1.3.132.0.33",
+        "PublicKeyLengthBits": 224
+      },
+      {
+        "Name": "nistP256",
+        "Oid": "1.2.840.10045.3.1.7",
+        "PublicKeyLengthBits": 256
+      },
+      {
+        "Name": "nistP384",
+        "Oid": "1.3.132.0.34",
+        "PublicKeyLengthBits": 384
+      },
+      {
+        "Name": "nistP521",
+        "Oid": "1.3.132.0.35",
+        "PublicKeyLengthBits": 521
+      },
+      {
+        "Name": "numsP256t1",
+        "Oid": "",
+        "PublicKeyLengthBits": 256
+      },
+      {
+        "Name": "numsP384t1",
+        "Oid": "",
+        "PublicKeyLengthBits": 384
+      },
+      {
+        "Name": "numsP512t1",
+        "Oid": "",
+        "PublicKeyLengthBits": 512
+      },
+      {
+        "Name": "secP160k1",
+        "Oid": "1.3.132.0.9",
+        "PublicKeyLengthBits": 160
+      },
+      {
+        "Name": "secP160r1",
+        "Oid": "1.3.132.0.8",
+        "PublicKeyLengthBits": 160
+      },
+      {
+        "Name": "secP160r2",
+        "Oid": "1.3.132.0.30",
+        "PublicKeyLengthBits": 160
+      },
+      {
+        "Name": "secP192k1",
+        "Oid": "1.3.132.0.31",
+        "PublicKeyLengthBits": 192
+      },
+      {
+        "Name": "secP192r1",
+        "Oid": "1.2.840.10045.3.1.1",
+        "PublicKeyLengthBits": 192
+      },
+      {
+        "Name": "secP224k1",
+        "Oid": "1.3.132.0.32",
+        "PublicKeyLengthBits": 224
+      },
+      {
+        "Name": "secP224r1",
+        "Oid": "1.3.132.0.33",
+        "PublicKeyLengthBits": 224
+      },
+      {
+        "Name": "secP256k1",
+        "Oid": "1.3.132.0.10",
+        "PublicKeyLengthBits": 256
+      },
+      {
+        "Name": "secP256r1",
+        "Oid": "1.2.840.10045.3.1.7",
+        "PublicKeyLengthBits": 256
+      },
+      {
+        "Name": "secP384r1",
+        "Oid": "1.3.132.0.34",
+        "PublicKeyLengthBits": 384
+      },
+      {
+        "Name": "secP521r1",
+        "Oid": "1.3.132.0.35",
+        "PublicKeyLengthBits": 521
+      },
+      {
+        "Name": "wtls12",
+        "Oid": "1.3.132.0.33",
+        "PublicKeyLengthBits": 224
+      },
+      {
+        "Name": "wtls7",
+        "Oid": "1.3.132.0.30",
+        "PublicKeyLengthBits": 160
+      },
+      {
+        "Name": "wtls9",
+        "Oid": "2.23.43.1.4.9",
+        "PublicKeyLengthBits": 160
+      },
+      {
+        "Name": "x962P192v1",
+        "Oid": "1.2.840.10045.3.1.1",
+        "PublicKeyLengthBits": 192
+      },
+      {
+        "Name": "x962P192v2",
+        "Oid": "1.2.840.10045.3.1.2",
+        "PublicKeyLengthBits": 192
+      },
+      {
+        "Name": "x962P192v3",
+        "Oid": "1.2.840.10045.3.1.3",
+        "PublicKeyLengthBits": 192
+      },
+      {
+        "Name": "x962P239v1",
+        "Oid": "1.2.840.10045.3.1.4",
+        "PublicKeyLengthBits": 239
+      },
+      {
+        "Name": "x962P239v2",
+        "Oid": "1.2.840.10045.3.1.5",
+        "PublicKeyLengthBits": 239
+      },
+      {
+        "Name": "x962P239v3",
+        "Oid": "1.2.840.10045.3.1.6",
+        "PublicKeyLengthBits": 239
+      },
+      {
+        "Name": "x962P256v1",
+        "Oid": "1.2.840.10045.3.1.7",
+        "PublicKeyLengthBits": 256
+      }
+    ],
+    "SslProviderCurves": [
+      {
+        "Name": "curve25519",
+        "Oid": "",
+        "PublicKeyLengthBits": 255,
+        "CurveType": 29,
+        "Flags": 10
+      },
+      {
+        "Name": "nistP256",
+        "Oid": "1.2.840.10045.3.1.7",
+        "PublicKeyLengthBits": 256,
+        "CurveType": 23,
+        "Flags": 7
+      },
+      {
+        "Name": "nistP384",
+        "Oid": "1.3.132.0.34",
+        "PublicKeyLengthBits": 384,
+        "CurveType": 24,
+        "Flags": 7
+      },
+      {
+        "Name": "brainpoolP256r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.7",
+        "PublicKeyLengthBits": 256,
+        "CurveType": 26,
+        "Flags": 7
+      },
+      {
+        "Name": "brainpoolP384r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.11",
+        "PublicKeyLengthBits": 384,
+        "CurveType": 27,
+        "Flags": 7
+      },
+      {
+        "Name": "brainpoolP512r1",
+        "Oid": "1.3.36.3.3.2.8.1.1.13",
+        "PublicKeyLengthBits": 512,
+        "CurveType": 28,
+        "Flags": 7
+      },
+      {
+        "Name": "nistP192",
+        "Oid": "1.2.840.10045.3.1.1",
+        "PublicKeyLengthBits": 192,
+        "CurveType": 19,
+        "Flags": 7
+      },
+      {
+        "Name": "nistP224",
+        "Oid": "1.3.132.0.33",
+        "PublicKeyLengthBits": 224,
+        "CurveType": 21,
+        "Flags": 7
+      },
+      {
+        "Name": "nistP521",
+        "Oid": "1.3.132.0.35",
+        "PublicKeyLengthBits": 521,
+        "CurveType": 25,
+        "Flags": 7
+      },
+      {
+        "Name": "secP160k1",
+        "Oid": "1.3.132.0.9",
+        "PublicKeyLengthBits": 160,
+        "CurveType": 15,
+        "Flags": 7
+      },
+      {
+        "Name": "secP160r1",
+        "Oid": "1.3.132.0.8",
+        "PublicKeyLengthBits": 160,
+        "CurveType": 16,
+        "Flags": 7
+      },
+      {
+        "Name": "secP160r2",
+        "Oid": "1.3.132.0.30",
+        "PublicKeyLengthBits": 160,
+        "CurveType": 17,
+        "Flags": 7
+      },
+      {
+        "Name": "secP192k1",
+        "Oid": "1.3.132.0.31",
+        "PublicKeyLengthBits": 192,
+        "CurveType": 18,
+        "Flags": 7
+      },
+      {
+        "Name": "secP192r1",
+        "Oid": "1.2.840.10045.3.1.1",
+        "PublicKeyLengthBits": 192,
+        "CurveType": 19,
+        "Flags": 7
+      },
+      {
+        "Name": "secP224k1",
+        "Oid": "1.3.132.0.32",
+        "PublicKeyLengthBits": 224,
+        "CurveType": 20,
+        "Flags": 7
+      },
+      {
+        "Name": "secP224r1",
+        "Oid": "1.3.132.0.33",
+        "PublicKeyLengthBits": 224,
+        "CurveType": 21,
+        "Flags": 7
+      },
+      {
+        "Name": "secP256k1",
+        "Oid": "1.3.132.0.10",
+        "PublicKeyLengthBits": 256,
+        "CurveType": 22,
+        "Flags": 7
+      },
+      {
+        "Name": "secP256r1",
+        "Oid": "1.2.840.10045.3.1.7",
+        "PublicKeyLengthBits": 256,
+        "CurveType": 23,
+        "Flags": 7
+      },
+      {
+        "Name": "secP384r1",
+        "Oid": "1.3.132.0.34",
+        "PublicKeyLengthBits": 384,
+        "CurveType": 24,
+        "Flags": 7
+      },
+      {
+        "Name": "secP521r1",
+        "Oid": "1.3.132.0.35",
+        "PublicKeyLengthBits": 521,
+        "CurveType": 25,
+        "Flags": 7
+      }
+    ],
+    "TlsCipherSuites": [
+      {
+        "Name": "TLS_CHACHA20_POLY1305_SHA256",
+        "Protocols": [
+          772
+        ],
+        "ProtocolNames": [
+          "TLS 1.3"
+        ],
+        "Cipher": "CHACHA20_POLY1305",
+        "CipherSuite": 4867,
+        "CipherSuiteHex": "0x1303",
+        "BaseCipherSuite": 4867,
+        "BaseCipherSuiteHex": "0x1303",
+        "CipherLength": 256,
+        "CipherBlockLength": 1,
+        "Hash": "",
+        "HashLength": 0,
+        "Exchange": "",
+        "MinimumExchangeLength": 0,
+        "MaximumExchangeLength": 0,
+        "Certificate": "",
+        "KeyType": 0
+      },
+      {
+        "Name": "TLS_AES_256_GCM_SHA384",
+        "Protocols": [
+          772
+        ],
+        "ProtocolNames": [
+          "TLS 1.3"
+        ],
+        "Cipher": "AES",
+        "CipherSuite": 4866,
+        "CipherSuiteHex": "0x1302",
+        "BaseCipherSuite": 4866,
+        "BaseCipherSuiteHex": "0x1302",
+        "CipherLength": 256,
+        "CipherBlockLength": 16,
+        "Hash": "",
+        "HashLength": 0,
+        "Exchange": "",
+        "MinimumExchangeLength": 0,
+        "MaximumExchangeLength": 0,
+        "Certificate": "",
+        "KeyType": 0
+      },
+      {
+        "Name": "TLS_AES_128_GCM_SHA256",
+        "Protocols": [
+          772
+        ],
+        "ProtocolNames": [
+          "TLS 1.3"
+        ],
+        "Cipher": "AES",
+        "CipherSuite": 4865,
+        "CipherSuiteHex": "0x1301",
+        "BaseCipherSuite": 4865,
+        "BaseCipherSuiteHex": "0x1301",
+        "CipherLength": 128,
+        "CipherBlockLength": 16,
+        "Hash": "",
+        "HashLength": 0,
+        "Exchange": "",
+        "MinimumExchangeLength": 0,
+        "MaximumExchangeLength": 0,
+        "Certificate": "",
+        "KeyType": 0
+      },
+      {
+        "Name": "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "Protocols": [
+          771,
+          65277
+        ],
+        "ProtocolNames": [
+          "TLS 1.2",
+          "DTLS 1.2"
+        ],
+        "Cipher": "AES",
+        "CipherSuite": 49196,
+        "CipherSuiteHex": "0xC02C",
+        "BaseCipherSuite": 49196,
+        "BaseCipherSuiteHex": "0xC02C",
+        "CipherLength": 256,
+        "CipherBlockLength": 16,
+        "Hash": "",
+        "HashLength": 0,
+        "Exchange": "ECDH",
+        "MinimumExchangeLength": 0,
+        "MaximumExchangeLength": 65536,
+        "Certificate": "ECDSA",
+        "KeyType": 0
+      },
+      {
+        "Name": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "Protocols": [
+          771,
+          65277
+        ],
+        "ProtocolNames": [
+          "TLS 1.2",
+          "DTLS 1.2"
+        ],
+        "Cipher": "AES",
+        "CipherSuite": 49195,
+        "CipherSuiteHex": "0xC02B",
+        "BaseCipherSuite": 49195,
+        "BaseCipherSuiteHex": "0xC02B",
+        "CipherLength": 128,
+        "CipherBlockLength": 16,
+        "Hash": "",
+        "HashLength": 0,
+        "Exchange": "ECDH",
+        "MinimumExchangeLength": 0,
+        "MaximumExchangeLength": 65536,
+        "Certificate": "ECDSA",
+        "KeyType": 0
+      },
+      {
+        "Name": "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "Protocols": [
+          771,
+          65277
+        ],
+        "ProtocolNames": [
+          "TLS 1.2",
+          "DTLS 1.2"
+        ],
+        "Cipher": "AES",
+        "CipherSuite": 49200,
+        "CipherSuiteHex": "0xC030",
+        "BaseCipherSuite": 49200,
+        "BaseCipherSuiteHex": "0xC030",
+        "CipherLength": 256,
+        "CipherBlockLength": 16,
+        "Hash": "",
+        "HashLength": 0,
+        "Exchange": "ECDH",
+        "MinimumExchangeLength": 0,
+        "MaximumExchangeLength": 65536,
+        "Certificate": "RSA",
+        "KeyType": 0
+      },
+      {
+        "Name": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "Protocols": [
+          771,
+          65277
+        ],
+        "ProtocolNames": [
+          "TLS 1.2",
+          "DTLS 1.2"
+        ],
+        "Cipher": "AES",
+        "CipherSuite": 49199,
+        "CipherSuiteHex": "0xC02F",
+        "BaseCipherSuite": 49199,
+        "BaseCipherSuiteHex": "0xC02F",
+        "CipherLength": 128,
+        "CipherBlockLength": 16,
+        "Hash": "",
+        "HashLength": 0,
+        "Exchange": "ECDH",
+        "MinimumExchangeLength": 0,
+        "MaximumExchangeLength": 65536,
+        "Certificate": "RSA",
+        "KeyType": 0
+      },
+      {
+        "Name": "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+        "Protocols": [
+          771,
+          65277
+        ],
+        "ProtocolNames": [
+          "TLS 1.2",
+          "DTLS 1.2"
+        ],
+        "Cipher": "AES",
+        "CipherSuite": 159,
+        "CipherSuiteHex": "0x009F",
+        "BaseCipherSuite": 159,
+        "BaseCipherSuiteHex": "0x009F",
+        "CipherLength": 256,
+        "CipherBlockLength": 16,
+        "Hash": "",
+        "HashLength": 0,
+        "Exchange": "DH",
+        "MinimumExchangeLength": 1024,
+        "MaximumExchangeLength": 1024,
+        "Certificate": "RSA",
+        "KeyType": 0
+      },
+      {
+        "Name": "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+        "Protocols": [
+          771,
+          65277
+        ],
+        "ProtocolNames": [
+          "TLS 1.2",
+          "DTLS 1.2"
+        ],
+        "Cipher": "AES",
+        "CipherSuite": 158,
+        "CipherSuiteHex": "0x009E",
+        "BaseCipherSuite": 158,
+        "BaseCipherSuiteHex": "0x009E",
+        "CipherLength": 128,
+        "CipherBlockLength": 16,
+        "Hash": "",
+        "HashLength": 0,
+        "Exchange": "DH",
+        "MinimumExchangeLength": 1024,
+        "MaximumExchangeLength": 1024,
+        "Certificate": "RSA",
+        "KeyType": 0
+      }
+    ],
+    "RegisteredProviders": [
+      "Microsoft Key Protection Provider",
+      "Microsoft Passport Key Storage Provider",
+      "Microsoft Platform Crypto Provider",
+      "Microsoft Primitive Provider",
+      "Microsoft Smart Card Key Storage Provider",
+      "Microsoft Software Key Storage Provider",
+      "Microsoft SSL Protocol Provider",
+      "Windows Client Key Protection Provider"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- **`Ensure-Apps.ps1`** — SuperOps SYSTEM bootstrap for new endpoints. Installs PowerShell 7, Chrome, Google Drive machine-scope via winget; registers a per-user scheduled task (logon + daily 03:00) that installs the HSS Microsoft Store app in the user's context with retry backoff. Writes status flags under `HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps`.
- **`Verify-Apps.ps1`** — drift detector for SuperOps daily schedule. Exits non-zero if any expected app is missing, surfacing alerts.
- **`includes/AA-Apply-HardenSystemSecurity.ps1`** — runs first in the orchestrator chain. Resolves `HSS.exe` via `Get-AppxPackage -AllUsers` (works under SYSTEM where AppExecutionAlias doesn't), invokes `HSS.exe --cli ImportReport --in=<report> --mode=full` (documented HSS CLI), and skips when the report's SHA-256 matches the value stored at `HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity\ReportHash`.
- **`includes/Harden-System-Security.report.json`** — exported HSS report that drives the apply step.

## Architecture
| Concern | Where | Runs as |
|---|---|---|
| Install winget / PS7 / Chrome / Drive | `Ensure-Apps.ps1` (one-shot SuperOps push) | SYSTEM |
| Install HSS (per-user MSIX) | Scheduled task `\CustomizeWindowsSetup\Install-UserApps` | Logged-in user |
| Apply HSS report | `includes/AA-Apply-HardenSystemSecurity.ps1` via `customize-windows-client.ps1` | SYSTEM |
| Drift monitoring | `Verify-Apps.ps1` (daily SuperOps schedule) | SYSTEM |

## Test plan
- [x] Verified `Verify-Apps.ps1` reports OK for all five apps after Bootstrap + first user logon.
- [ ] Run `customize-windows-client.ps1` once HSS is installed — confirm `LastAppliedUtc` populates under `HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity`.
- [ ] Re-run customize — confirm AA-Apply step skips with "report unchanged" message.
- [ ] Schedule `Verify-Apps.ps1` daily in SuperOps and confirm alert fires when registry flag is removed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)