### PR TITLE
Fix read-only $host variable in download-repo.ps1

### DIFF
--- a/download-repo.ps1
+++ b/download-repo.ps1
@@ -52,12 +52,12 @@ $expectedExe = Join-Path $expectedDir $EntryPoint
 # --- 1. Preflight: can we resolve github.com / codeload.github.com? -------
 Write-Host '[INFO] DNS preflight...' -ForegroundColor Cyan
 $dnsOk = $true
-foreach ($host in @('github.com', 'codeload.github.com')) {
+foreach ($dnsHost in @('github.com', 'codeload.github.com')) {
     try {
-        $null = Resolve-DnsName -Name $host -Type A -ErrorAction Stop -QuickTimeout
-        Write-Host "  $host  OK"
+        $null = Resolve-DnsName -Name $dnsHost -Type A -ErrorAction Stop -QuickTimeout
+        Write-Host "  $dnsHost  OK"
     } catch {
-        Write-Host "  $host  FAIL ($_)" -ForegroundColor Yellow
+        Write-Host "  $dnsHost  FAIL ($_)" -ForegroundColor Yellow
         $dnsOk = $false
     }
 }


### PR DESCRIPTION
## Summary
Renamed the DNS preflight loop variable from \`\$host\` to \`\$dnsHost\` — \`\$Host\` is a PowerShell built-in read-only automatic variable, so the loop blew up on every endpoint with:

\`\`\`
Cannot overwrite variable Host because it is read-only or constant.
\`\`\`

…which caused the script to exit 1 immediately, before any download was attempted.

## Test plan
- [x] Verified rename doesn't affect any other reference.
- [ ] Re-run SuperOps wrapper on the test endpoint — preflight should now print \`github.com  OK\` / \`codeload.github.com  OK\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)