### PR TITLE
Fix five bugs from SuperOps customize run

### DIFF
--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -100,22 +100,12 @@ try {
         }
     }
     $srRegPath = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\SystemRestore'
-    $freq = (Get-ItemProperty -Path $srRegPath -Name SystemRestorePointCreationFrequency -ErrorAction SilentlyContinue).SystemRestorePointCreationFrequency
-    if (-not $freq) { $freq = 0 }
-    $skipRestore = $false
-    if ($freq -gt 0) {
-        $last = Get-ComputerRestorePoint | Sort-Object -Property CreationTime -Descending | Select-Object -First 1
-        if ($last) {
-            $elapsed = (New-TimeSpan -Start $last.CreationTime -End (Get-Date)).TotalMinutes
-            if ($elapsed -lt $freq) {
-                Write-Host "[INFO] Last restore point created $([math]::Round($elapsed)) minutes ago. Skipping new restore point." -ForegroundColor Yellow
-                $skipRestore = $true
-            }
-        }
-    }
-    if (-not $skipRestore) {
-        Checkpoint-Computer -Description "Before customizations" -RestorePointType MODIFY_SETTINGS | Out-Null
-    }
+    # Windows throttles restore-point creation to one per 24h by default. Set the
+    # frequency override to 0 so every customize run gets its own safety net.
+    if (-not (Test-Path $srRegPath)) { New-Item -Path $srRegPath -Force | Out-Null }
+    Set-ItemProperty -Path $srRegPath -Name SystemRestorePointCreationFrequency -Value 0 -Type DWord -Force
+    Checkpoint-Computer -Description "Before customizations" -RestorePointType MODIFY_SETTINGS | Out-Null
+    Write-Host "[OK] System restore point created" -ForegroundColor Green
 } catch {
     Write-Warning "Failed to create restore point: $_"
     $ScriptSuccess = $false
@@ -131,6 +121,11 @@ try {
     if(!(Test-Path $INSTALLFOLDER)) {
         New-Item -ItemType Directory -Force -Path $INSTALLFOLDER | Out-Null
     }
+    # Clear per-run sentinel files used by machine-wide includes to avoid
+    # repeating themselves once per user-hive iteration. They're recreated
+    # by the relevant scripts the first time they run this session.
+    Get-ChildItem -Path $TEMPFOLDER -Filter '*.session' -File -ErrorAction SilentlyContinue |
+        Remove-Item -Force -ErrorAction SilentlyContinue
 } catch {
     Write-Warning "Failed to create folders: $_"
     $ScriptSuccess = $false
@@ -148,10 +143,12 @@ $regBackupFiles = @{
 foreach ($hive in $regBackupFiles.Keys) {
     $file = $regBackupFiles[$hive]
     try {
-        reg.exe export $hive $file /y
+        # Suppress reg.exe's noisy stdout/stderr; we report success/failure ourselves.
+        $regOutput = reg.exe export $hive $file /y 2>&1
         if ($LASTEXITCODE -ne 0 -or -not (Test-Path $file) -or (Get-Item $file).Length -eq 0) {
-            throw "Registry export for $hive failed"
+            throw "reg.exe exit=$LASTEXITCODE output=$regOutput"
         }
+        Write-Host "[OK] Backed up $hive -> $file" -ForegroundColor Green
     } catch {
         Write-Warning "Failed to backup registry hive ${hive}: $_"
         $ScriptSuccess = $false
@@ -183,14 +180,15 @@ foreach ($hive in $userHives) {
     $sid = $hive.PSChildName
     $file = Join-Path $hkuBackupDir ("registry-backup-hku-$sid.reg")
     try {
-        reg.exe export "HKU\$sid" $file /y
+        $regOutput = reg.exe export "HKU\$sid" $file /y 2>&1
         if ($LASTEXITCODE -ne 0 -or -not (Test-Path $file) -or (Get-Item $file).Length -eq 0) {
-            throw "Registry export for HKU\$sid failed"
+            throw "reg.exe exit=$LASTEXITCODE output=$regOutput"
         }
+        Write-Host "[OK] Backed up HKU\$sid" -ForegroundColor Green
     } catch {
-        Write-Warning "Failed to backup registry hive HKU\${sid}: $_"
-        $ScriptSuccess = $false
-        $ErrorMessages += "Registry backup HKU\${sid}: $_"
+        # Some loaded hives (system-protected SIDs like DefaultUser overlays) deny read access.
+        # Log a warning but don't mark the whole script as failed — these aren't critical.
+        Write-Warning "Skipped HKU\${sid} backup: $_"
     }
 }
 

--- a/download-repo.ps1
+++ b/download-repo.ps1
@@ -52,12 +52,12 @@ $expectedExe = Join-Path $expectedDir $EntryPoint
 # --- 1. Preflight: can we resolve github.com / codeload.github.com? -------
 Write-Host '[INFO] DNS preflight...' -ForegroundColor Cyan
 $dnsOk = $true
-foreach ($host in @('github.com', 'codeload.github.com')) {
+foreach ($dnsHost in @('github.com', 'codeload.github.com')) {
     try {
-        $null = Resolve-DnsName -Name $host -Type A -ErrorAction Stop -QuickTimeout
-        Write-Host "  $host  OK"
+        $null = Resolve-DnsName -Name $dnsHost -Type A -ErrorAction Stop -QuickTimeout
+        Write-Host "  $dnsHost  OK"
     } catch {
-        Write-Host "  $host  FAIL ($_)" -ForegroundColor Yellow
+        Write-Host "  $dnsHost  FAIL ($_)" -ForegroundColor Yellow
         $dnsOk = $false
     }
 }

--- a/includes/AA-Apply-HardenSystemSecurity.ps1
+++ b/includes/AA-Apply-HardenSystemSecurity.ps1
@@ -26,6 +26,15 @@ $StateKey   = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
 $StoreId    = '9p7ggfl7dx57'
 $PkgFamily  = 'VioletHansen.HardenSystemSecurity_ea7andspwdn10'
 $PkgName    = 'VioletHansen.HardenSystemSecurity'
+$SessionSentinel = 'C:\Temp\AA-Apply-HardenSystemSecurity.session'
+
+# Orchestrator re-invokes each include once per user hive. This script is
+# machine-wide — only run it the first time. Use a sentinel file rooted in
+# the customize-run's working directory so it auto-clears between runs.
+if (Test-Path -LiteralPath $SessionSentinel) {
+    return
+}
+New-Item -Path $SessionSentinel -ItemType File -Force | Out-Null
 
 if (-not (Test-Path -LiteralPath $ReportFile)) {
     Write-Log "ERROR: Harden System Security report not found at $ReportFile"
@@ -98,6 +107,11 @@ try {
 
     $hss = Resolve-HssExe
     if (-not $hss) {
+        if (Test-IsSystem) {
+            Write-Host '[SKIP] Harden System Security not installed yet (waiting for user-logon install task to fire). Will apply on a later run.' -ForegroundColor Yellow
+            Write-Log 'Harden System Security: skipped — package not yet installed under SYSTEM context.'
+            return
+        }
         Install-Hss
         $hss = Resolve-HssExe
         if (-not $hss) { throw 'HSS.exe still not found after install attempt.' }

--- a/includes/Enable-WakeOnLan.ps1
+++ b/includes/Enable-WakeOnLan.ps1
@@ -7,15 +7,17 @@ $allAdapters = Get-NetAdapter
 Write-Host "[INFO] Found $($allAdapters.Count) total network adapters"
 
 # Filter for physical network adapters using a more universal approach
-$eligibleAdapters = Get-NetAdapter | Where-Object {
+# Force array context with @(...) so .Count always returns the correct number,
+# even when Where-Object yields a single object (PowerShell otherwise unwraps it).
+$eligibleAdapters = @(Get-NetAdapter | Where-Object {
     # Must be a hardware interface (not virtual)
     $_.HardwareInterface -eq $true -and
     # Exclude known virtual/software adapters by description patterns
     $_.InterfaceDescription -notmatch "Virtual|VPN|TAP|Loopback|Teredo|6to4|Fortinet|Hyper-V|VMware|Bluetooth|Tunnel" -and
     # Only include adapters that can potentially support Wake on LAN (have advanced properties)
-    (Get-NetAdapterAdvancedProperty -Name $_.Name -ErrorAction SilentlyContinue | 
+    (Get-NetAdapterAdvancedProperty -Name $_.Name -ErrorAction SilentlyContinue |
      Where-Object { $_.DisplayName -match "Wake|Power" }) -ne $null
-}
+})
 
 Write-Host "[INFO] Found $($eligibleAdapters.Count) eligible physical network adapters"
 

--- a/includes/Set-PowerManagement-HighPerformance.ps1
+++ b/includes/Set-PowerManagement-HighPerformance.ps1
@@ -4,16 +4,27 @@
 Write-Host "Configuring High Performance power plan with screen lock..." -ForegroundColor Cyan
 
 Try {
-    # Get High Performance plan GUID
-    $highPerf = powercfg -l | ForEach-Object{if($_.contains($POWERMANAGEMENT)) {$_.split()[3]}}
-    $currPlan = $(powercfg -getactivescheme).split()[3]
-    
-    # Switch to High Performance if not already active
-    if ($currPlan -ne $highPerf) {
-        powercfg -setactive $highPerf
-        Write-Host "[POWER] Switched to High Performance plan" -ForegroundColor Green
+    # Get High Performance plan GUID. On Win11 Home / certain SKUs the plan
+    # isn't pre-installed; we duplicate from the well-known builtin GUID if so.
+    $builtinHighPerf = '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+    $highPerf = powercfg -l | ForEach-Object { if ($_.contains($POWERMANAGEMENT)) { $_.split()[3] } } | Select-Object -First 1
+    if (-not $highPerf) {
+        Write-Host "[POWER] High Performance plan not present; creating from builtin..." -ForegroundColor Yellow
+        $dup = powercfg -duplicatescheme $builtinHighPerf 2>&1
+        if ($dup -match '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})') {
+            $highPerf = $matches[1]
+        }
+    }
+    if (-not $highPerf) {
+        Write-Warning "Could not locate or create a High Performance plan. Skipping plan switch."
     } else {
-        Write-Host "[POWER] Already using High Performance plan" -ForegroundColor Gray
+        $currPlan = $(powercfg -getactivescheme).split()[3]
+        if ($currPlan -ne $highPerf) {
+            powercfg -setactive $highPerf
+            Write-Host "[POWER] Switched to High Performance plan" -ForegroundColor Green
+        } else {
+            Write-Host "[POWER] Already using High Performance plan" -ForegroundColor Gray
+        }
     }
     
     # Get the active scheme GUID for modification


### PR DESCRIPTION
## Summary
Concrete bug fixes from running the customize script via SuperOps on a real endpoint. None of these were breaking the run, but they produced misleading or noisy output and a couple were genuinely wrong.

| # | File | Bug | Fix |
|---|---|---|---|
| 1 | \`customize-windows-client.ps1\` | Windows blocked restore point because one already existed in last 24h | Force \`SystemRestorePointCreationFrequency=0\` before \`Checkpoint-Computer\` |
| 2 | \`customize-windows-client.ps1\` | Bare \`ERROR: Access is denied.\` from \`reg.exe\` on a protected hive marked the whole script failed | Capture stderr, wrap in our own warning, don't fail script for non-critical per-SID backup failures |
| 3 | \`includes/Set-PowerManagement-HighPerformance.ps1\` | Empty \`\$highPerf\` → \`powercfg -setactive\` printed \"Invalid Parameters\" followed by misleading \"Switched\" success | Detect missing plan, duplicate from builtin GUID, guard with explicit nil check |
| 4 | \`includes/Enable-WakeOnLan.ps1\` | \`\$eligibleAdapters.Count\` empty when only one adapter qualified (PS unwrap) | Force array context with \`@(...)\` |
| 5 | \`includes/AA-Apply-HardenSystemSecurity.ps1\` | Ran 3× per orchestrator run (once per user hive), each printed [ERROR] when HSS not yet installed under SYSTEM | Per-run \`.session\` sentinel + friendly [SKIP] under SYSTEM; orchestrator clears sentinels at startup |

## Known follow-up (not in this PR)
Many includes that only touch HKLM still re-run for each user hive iteration (cosmetic only — they're idempotent). The \`.session\` sentinel pattern introduced here is the building block for the cleanup; happy to apply it to the other machine-wide scripts in a follow-up.

## Test plan
- [ ] Run customize on a fresh endpoint via SuperOps wrapper.
- [ ] Confirm \"[OK] System restore point created\" appears.
- [ ] Confirm registry backup section either prints all \"[OK] Backed up …\" lines or a single coherent warning (no more bare reg.exe error).
- [ ] Confirm Set-PowerManagement no longer prints \"Invalid Parameters\".
- [ ] Confirm Enable-WakeOnLan reports the adapter count.
- [ ] Confirm AA-Apply prints exactly once per customize run (look for \"[SKIP] Harden System Security not installed yet\" if HSS still isn't on the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)