### PR TITLE
Fix Disable-XBox.ps1 truncation

### DIFF
--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -100,22 +100,12 @@ try {
         }
     }
     $srRegPath = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\SystemRestore'
-    $freq = (Get-ItemProperty -Path $srRegPath -Name SystemRestorePointCreationFrequency -ErrorAction SilentlyContinue).SystemRestorePointCreationFrequency
-    if (-not $freq) { $freq = 0 }
-    $skipRestore = $false
-    if ($freq -gt 0) {
-        $last = Get-ComputerRestorePoint | Sort-Object -Property CreationTime -Descending | Select-Object -First 1
-        if ($last) {
-            $elapsed = (New-TimeSpan -Start $last.CreationTime -End (Get-Date)).TotalMinutes
-            if ($elapsed -lt $freq) {
-                Write-Host "[INFO] Last restore point created $([math]::Round($elapsed)) minutes ago. Skipping new restore point." -ForegroundColor Yellow
-                $skipRestore = $true
-            }
-        }
-    }
-    if (-not $skipRestore) {
-        Checkpoint-Computer -Description "Before customizations" -RestorePointType MODIFY_SETTINGS | Out-Null
-    }
+    # Windows throttles restore-point creation to one per 24h by default. Set the
+    # frequency override to 0 so every customize run gets its own safety net.
+    if (-not (Test-Path $srRegPath)) { New-Item -Path $srRegPath -Force | Out-Null }
+    Set-ItemProperty -Path $srRegPath -Name SystemRestorePointCreationFrequency -Value 0 -Type DWord -Force
+    Checkpoint-Computer -Description "Before customizations" -RestorePointType MODIFY_SETTINGS | Out-Null
+    Write-Host "[OK] System restore point created" -ForegroundColor Green
 } catch {
     Write-Warning "Failed to create restore point: $_"
     $ScriptSuccess = $false
@@ -131,6 +121,11 @@ try {
     if(!(Test-Path $INSTALLFOLDER)) {
         New-Item -ItemType Directory -Force -Path $INSTALLFOLDER | Out-Null
     }
+    # Clear per-run sentinel files used by machine-wide includes to avoid
+    # repeating themselves once per user-hive iteration. They're recreated
+    # by the relevant scripts the first time they run this session.
+    Get-ChildItem -Path $TEMPFOLDER -Filter '*.session' -File -ErrorAction SilentlyContinue |
+        Remove-Item -Force -ErrorAction SilentlyContinue
 } catch {
     Write-Warning "Failed to create folders: $_"
     $ScriptSuccess = $false
@@ -148,10 +143,12 @@ $regBackupFiles = @{
 foreach ($hive in $regBackupFiles.Keys) {
     $file = $regBackupFiles[$hive]
     try {
-        reg.exe export $hive $file /y
+        # Suppress reg.exe's noisy stdout/stderr; we report success/failure ourselves.
+        $regOutput = reg.exe export $hive $file /y 2>&1
         if ($LASTEXITCODE -ne 0 -or -not (Test-Path $file) -or (Get-Item $file).Length -eq 0) {
-            throw "Registry export for $hive failed"
+            throw "reg.exe exit=$LASTEXITCODE output=$regOutput"
         }
+        Write-Host "[OK] Backed up $hive -> $file" -ForegroundColor Green
     } catch {
         Write-Warning "Failed to backup registry hive ${hive}: $_"
         $ScriptSuccess = $false
@@ -183,14 +180,15 @@ foreach ($hive in $userHives) {
     $sid = $hive.PSChildName
     $file = Join-Path $hkuBackupDir ("registry-backup-hku-$sid.reg")
     try {
-        reg.exe export "HKU\$sid" $file /y
+        $regOutput = reg.exe export "HKU\$sid" $file /y 2>&1
         if ($LASTEXITCODE -ne 0 -or -not (Test-Path $file) -or (Get-Item $file).Length -eq 0) {
-            throw "Registry export for HKU\$sid failed"
+            throw "reg.exe exit=$LASTEXITCODE output=$regOutput"
         }
+        Write-Host "[OK] Backed up HKU\$sid" -ForegroundColor Green
     } catch {
-        Write-Warning "Failed to backup registry hive HKU\${sid}: $_"
-        $ScriptSuccess = $false
-        $ErrorMessages += "Registry backup HKU\${sid}: $_"
+        # Some loaded hives (system-protected SIDs like DefaultUser overlays) deny read access.
+        # Log a warning but don't mark the whole script as failed — these aren't critical.
+        Write-Warning "Skipped HKU\${sid} backup: $_"
     }
 }
 

--- a/download-repo.ps1
+++ b/download-repo.ps1
@@ -52,12 +52,12 @@ $expectedExe = Join-Path $expectedDir $EntryPoint
 # --- 1. Preflight: can we resolve github.com / codeload.github.com? -------
 Write-Host '[INFO] DNS preflight...' -ForegroundColor Cyan
 $dnsOk = $true
-foreach ($host in @('github.com', 'codeload.github.com')) {
+foreach ($dnsHost in @('github.com', 'codeload.github.com')) {
     try {
-        $null = Resolve-DnsName -Name $host -Type A -ErrorAction Stop -QuickTimeout
-        Write-Host "  $host  OK"
+        $null = Resolve-DnsName -Name $dnsHost -Type A -ErrorAction Stop -QuickTimeout
+        Write-Host "  $dnsHost  OK"
     } catch {
-        Write-Host "  $host  FAIL ($_)" -ForegroundColor Yellow
+        Write-Host "  $dnsHost  FAIL ($_)" -ForegroundColor Yellow
         $dnsOk = $false
     }
 }

--- a/includes/AA-Apply-HardenSystemSecurity.ps1
+++ b/includes/AA-Apply-HardenSystemSecurity.ps1
@@ -26,6 +26,15 @@ $StateKey   = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
 $StoreId    = '9p7ggfl7dx57'
 $PkgFamily  = 'VioletHansen.HardenSystemSecurity_ea7andspwdn10'
 $PkgName    = 'VioletHansen.HardenSystemSecurity'
+$SessionSentinel = 'C:\Temp\AA-Apply-HardenSystemSecurity.session'
+
+# Orchestrator re-invokes each include once per user hive. This script is
+# machine-wide — only run it the first time. Use a sentinel file rooted in
+# the customize-run's working directory so it auto-clears between runs.
+if (Test-Path -LiteralPath $SessionSentinel) {
+    return
+}
+New-Item -Path $SessionSentinel -ItemType File -Force | Out-Null
 
 if (-not (Test-Path -LiteralPath $ReportFile)) {
     Write-Log "ERROR: Harden System Security report not found at $ReportFile"
@@ -98,6 +107,11 @@ try {
 
     $hss = Resolve-HssExe
     if (-not $hss) {
+        if (Test-IsSystem) {
+            Write-Host '[SKIP] Harden System Security not installed yet (waiting for user-logon install task to fire). Will apply on a later run.' -ForegroundColor Yellow
+            Write-Log 'Harden System Security: skipped — package not yet installed under SYSTEM context.'
+            return
+        }
         Install-Hss
         $hss = Resolve-HssExe
         if (-not $hss) { throw 'HSS.exe still not found after install attempt.' }

--- a/includes/AA-Apply-HardenSystemSecurity.ps1
+++ b/includes/AA-Apply-HardenSystemSecurity.ps1
@@ -21,20 +21,13 @@
 #   Same hash -> skip. Different/missing -> apply and update. To force a
 #   re-apply on the next run, delete that registry value.
 
+if (Test-MachineWideSentinel -Name 'AA-Apply-HardenSystemSecurity') { return }
+
 $ReportFile = Join-Path $PSScriptRoot 'Harden-System-Security.report.json'
 $StateKey   = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
 $StoreId    = '9p7ggfl7dx57'
 $PkgFamily  = 'VioletHansen.HardenSystemSecurity_ea7andspwdn10'
 $PkgName    = 'VioletHansen.HardenSystemSecurity'
-$SessionSentinel = 'C:\Temp\AA-Apply-HardenSystemSecurity.session'
-
-# Orchestrator re-invokes each include once per user hive. This script is
-# machine-wide — only run it the first time. Use a sentinel file rooted in
-# the customize-run's working directory so it auto-clears between runs.
-if (Test-Path -LiteralPath $SessionSentinel) {
-    return
-}
-New-Item -Path $SessionSentinel -ItemType File -Force | Out-Null
 
 if (-not (Test-Path -LiteralPath $ReportFile)) {
     Write-Log "ERROR: Harden System Security report not found at $ReportFile"

--- a/includes/Configure-Clipboard.ps1
+++ b/includes/Configure-Clipboard.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Configure-Clipboard') { return }
+
 # Configure Clipboard Settings
 
 # Enable clipboard history and disable cross-device sync for all users

--- a/includes/Disable-3D-Objects.ps1
+++ b/includes/Disable-3D-Objects.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Disable-3D-Objects') { return }
+
 # Hide 3D Objects icon from This PC - The icon remains in personal folders and open/save dialogs
 Remove-RegistryKey -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{0DB7E03F-FC29-4DC6-9020-FF41B59E513A}"
 

--- a/includes/Disable-Bing-Search.ps1
+++ b/includes/Disable-Bing-Search.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Disable-Bing-Search') { return }
+
 # Disable Bing Search
 try {
     $searchPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search"

--- a/includes/Disable-Cortana.ps1
+++ b/includes/Disable-Cortana.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Disable-Cortana') { return }
+
 # Disabling Cortana
 try {
     $inputPath = "HKLM:\SOFTWARE\Policies\Microsoft\InputPersonalization"

--- a/includes/Disable-FastStartup.ps1
+++ b/includes/Disable-FastStartup.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Disable-FastStartup') { return }
+
 # Disable Fast Startup to ensure proper WoL functionality and clean shutdown
 
 Write-Host "Disabling Fast Startup..."
@@ -10,4 +12,3 @@ try {
 }
 
 Write-Host "Fast Startup configuration complete."
-

--- a/includes/Disable-Guest-Account.ps1
+++ b/includes/Disable-Guest-Account.ps1
@@ -1,2 +1,4 @@
+if (Test-MachineWideSentinel -Name 'Disable-Guest-Account') { return }
+
 ## Disable guest account
 net.exe user guest /active:no

--- a/includes/Disable-Hibernation.ps1
+++ b/includes/Disable-Hibernation.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Disable-Hibernation') { return }
+
 # Disable hibernation (reclaims disk space, avoids hybrid sleep issues)
 powercfg.exe -h off
 Write-Host "[OK] Hibernation disabled to prevent hybrid sleep and reclaim disk space."

--- a/includes/Disable-WAC-Popup.ps1
+++ b/includes/Disable-WAC-Popup.ps1
@@ -1,7 +1,8 @@
+if (Test-MachineWideSentinel -Name 'Disable-WAC-Popup') { return }
+
 # Disable WAC pop-up in Server Manager on Windows Server 2019
 if ($WINDOWSBUILD -eq $WINDOWSSERVER2019) {
     # Registry path controlling the Server Manager welcome popup
     $regkeyServerManager = 'HKLM:\SOFTWARE\Microsoft\ServerManager'
     Set-RegistryValue -Path $regkeyServerManager -Name 'DoNotPopWACConsoleAtSMLaunch' -Value 1 -Type 'DWord' -Force
 }
-

--- a/includes/Disable-WAP-Service.ps1
+++ b/includes/Disable-WAP-Service.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Disable-WAP-Service') { return }
+
 # Stopping and disabling WAP Push Service
 Stop-ServiceSafely -ServiceName "dmwappushservice" -DisplayName "WAP Push Service"
 Set-ServiceStartupTypeSafely -ServiceName "dmwappushservice" -StartupType "Disabled" -DisplayName "WAP Push Service"

--- a/includes/Disable-WiFi-HotSpot-Autoconnect.ps1
+++ b/includes/Disable-WiFi-HotSpot-Autoconnect.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Disable-WiFi-HotSpot-Autoconnect') { return }
+
 # Disable WiFi Sense: HotSpot Sharing
 $hotSpotReportingPath = "HKLM:\Software\Microsoft\PolicyManager\default\WiFi\AllowWiFiHotSpotReporting"
 Set-RegistryValue -Path $hotSpotReportingPath -Name "value" -Value 0 -Type "DWord" -Force
@@ -5,4 +7,3 @@ Set-RegistryValue -Path $hotSpotReportingPath -Name "value" -Value 0 -Type "DWor
 # Disable WiFi Sense: Shared HotSpot Auto-Connect
 $autoConnectPath = "HKLM:\Software\Microsoft\PolicyManager\default\WiFi\AllowAutoConnectToWiFiSenseHotspots"
 Set-RegistryValue -Path $autoConnectPath -Name "value" -Value 0 -Type "DWord" -Force
-

--- a/includes/Disable-XBox.ps1
+++ b/includes/Disable-XBox.ps1
@@ -9,4 +9,13 @@ Get-AppxPackage "Microsoft.Xbox.TCUI" | Remove-AppxPackage
 # Apply system-wide policy to disable Game DVR
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\GameDVR" -Name "AllowGameDVR" -Value 0 -Type "DWord"
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR" -Name "value" -Value 0 -Type "DWord"
-Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager\current\ApplicationManagement\AllowGameDVR" -Name "value" -Value 0 -Type "DWord"
+
+# Clean up any per-user Game DVR settings
+$hives = Get-ChildItem 'Registry::HKEY_USERS' | Where-Object { $_.PSChildName -match '^S-1-5-' -and $_.PSChildName -notmatch '_Classes$' }
+foreach ($hive in $hives) {
+    $userPath = "Registry::$($hive.PSChildName)\System\GameConfigStore"
+    Remove-RegistryValue -Path $userPath -Name 'GameDVR_Enabled'
+}
+
+Remove-RegistryValue -Path 'HKU:\.DEFAULT\System\GameConfigStore' -Name 'GameDVR_Enabled'

--- a/includes/Disable-XBox.ps1
+++ b/includes/Disable-XBox.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Disable-XBox') { return }
+
 # Disable Xbox features
 Get-AppxPackage "Microsoft.XboxApp" | Remove-AppxPackage
 Get-AppxPackage "Microsoft.XboxIdentityProvider" | Remove-AppxPackage -ErrorAction SilentlyContinue
@@ -7,13 +9,4 @@ Get-AppxPackage "Microsoft.Xbox.TCUI" | Remove-AppxPackage
 # Apply system-wide policy to disable Game DVR
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\GameDVR" -Name "AllowGameDVR" -Value 0 -Type "DWord"
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR" -Name "value" -Value 0 -Type "DWord"
-Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager\current\ApplicationManagement\AllowGameDVR" -Name "value" -Value 0 -Type "DWord"
-
-# Clean up any per-user Game DVR settings
-$hives = Get-ChildItem 'Registry::HKEY_USERS' | Where-Object { $_.PSChildName -match '^S-1-5-' -and $_.PSChildName -notmatch '_Classes$' }
-foreach ($hive in $hives) {
-    $userPath = "Registry::$($hive.PSChildName)\System\GameConfigStore"
-    Remove-RegistryValue -Path $userPath -Name 'GameDVR_Enabled'
-}
-
-Remove-RegistryValue -Path 'HKU:\.DEFAULT\System\GameConfigStore' -Name 'GameDVR_Enabled'
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager

--- a/includes/Enable-AVMA.ps1
+++ b/includes/Enable-AVMA.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Enable-AVMA') { return }
+
 # Only run on Windows Server editions
 $isServer = ((Get-CimInstance Win32_OperatingSystem).ProductType -ne 1)
 if (-not $isServer) {

--- a/includes/Enable-NumLock.ps1
+++ b/includes/Enable-NumLock.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Enable-NumLock') { return }
+
 # Enable Num Lock by default for all users
 $initialValue = '2'
 $policyPath   = 'HKLM:\SOFTWARE\Policies\Microsoft\Control Panel\Keyboard'

--- a/includes/Enable-WakeOnLan.ps1
+++ b/includes/Enable-WakeOnLan.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Enable-WakeOnLan') { return }
+
 # Enable Wake on LAN (WoL) on the local machine
 
 Write-Host "[INFO] Configuring Wake on LAN..."

--- a/includes/Enable-WakeOnLan.ps1
+++ b/includes/Enable-WakeOnLan.ps1
@@ -7,15 +7,17 @@ $allAdapters = Get-NetAdapter
 Write-Host "[INFO] Found $($allAdapters.Count) total network adapters"
 
 # Filter for physical network adapters using a more universal approach
-$eligibleAdapters = Get-NetAdapter | Where-Object {
+# Force array context with @(...) so .Count always returns the correct number,
+# even when Where-Object yields a single object (PowerShell otherwise unwraps it).
+$eligibleAdapters = @(Get-NetAdapter | Where-Object {
     # Must be a hardware interface (not virtual)
     $_.HardwareInterface -eq $true -and
     # Exclude known virtual/software adapters by description patterns
     $_.InterfaceDescription -notmatch "Virtual|VPN|TAP|Loopback|Teredo|6to4|Fortinet|Hyper-V|VMware|Bluetooth|Tunnel" -and
     # Only include adapters that can potentially support Wake on LAN (have advanced properties)
-    (Get-NetAdapterAdvancedProperty -Name $_.Name -ErrorAction SilentlyContinue | 
+    (Get-NetAdapterAdvancedProperty -Name $_.Name -ErrorAction SilentlyContinue |
      Where-Object { $_.DisplayName -match "Wake|Power" }) -ne $null
-}
+})
 
 Write-Host "[INFO] Found $($eligibleAdapters.Count) eligible physical network adapters"
 

--- a/includes/Hide-All-Tray-Icons.ps1
+++ b/includes/Hide-All-Tray-Icons.ps1
@@ -1,2 +1,4 @@
+if (Test-MachineWideSentinel -Name 'Hide-All-Tray-Icons') { return }
+
 # Hide all tray icons
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "EnableAutoTray" -Value 1 -Type "DWord" -Force

--- a/includes/Hide-Music-Icons.ps1
+++ b/includes/Hide-Music-Icons.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Hide-Music-Icons') { return }
+
 # Hide Music icon from This PC - The icon remains in personal folders and open/save dialogs
 Remove-RegistryKey -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{3dfdf296-dbec-4fb4-81d1-6a3438bcf4de}"
 Remove-RegistryKey -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{1CF1260C-4DD0-4ebb-811F-33C572699FDE}"

--- a/includes/Hide-Picture-Icons.ps1
+++ b/includes/Hide-Picture-Icons.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Hide-Picture-Icons') { return }
+
 # Hide Pictures icon from This PC - The icon remains in personal folders and open/save dialogs
 Remove-RegistryKey -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{24ad3ad4-a569-4530-98e1-ab02f9417aa8}"
 Remove-RegistryKey -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{3ADD1653-EB32-4cb0-BBD7-DFA0ABB5ACCA}"

--- a/includes/Hide-Video-Icons.ps1
+++ b/includes/Hide-Video-Icons.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Hide-Video-Icons') { return }
+
 # Hide Videos icon from This PC - The icon remains in personal folders and open/save dialogs
 Remove-RegistryKey -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{f86fa3ab-70d2-4fc7-9c99-fcbf05467f3a}"
 Remove-RegistryKey -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{A0953C92-50DC-43bf-BE83-3742FED03C9C}"

--- a/includes/Hide-Widgets-Icon.ps1
+++ b/includes/Hide-Widgets-Icon.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Hide-Widgets-Icon') { return }
+
 # Hide Widgets icon on the taskbar for all users using policy keys
 Write-Host "Hiding Widgets icon on the taskbar system-wide..."
 

--- a/includes/Join-Workgroup.ps1
+++ b/includes/Join-Workgroup.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Join-Workgroup') { return }
+
 # Automatically join the predefined workgroup if not already joined
 $CurrentWorkgroup = (Get-WmiObject Win32_ComputerSystem).Workgroup
 $WORKGROUP = 'MYLOCALCHEMIST'

--- a/includes/Set-Control-Panel-View-to-Small-Icons.ps1
+++ b/includes/Set-Control-Panel-View-to-Small-Icons.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Set-Control-Panel-View-to-Small-Icons') { return }
+
 # Set Control Panel view to Small icons (Classic)
 $policyPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\ControlPanel"
 

--- a/includes/Set-InactivityTimeout.ps1
+++ b/includes/Set-InactivityTimeout.ps1
@@ -1,3 +1,4 @@
+if (Test-MachineWideSentinel -Name 'Set-InactivityTimeout') { return }
+
 # Set machine inactivity timeout to 30 minutes (1800 seconds)
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -Name "InactivityTimeoutSecs" -Value 1800 -Type "DWord" -Force
-

--- a/includes/Set-PowerManagement-HighPerformance.ps1
+++ b/includes/Set-PowerManagement-HighPerformance.ps1
@@ -4,16 +4,27 @@
 Write-Host "Configuring High Performance power plan with screen lock..." -ForegroundColor Cyan
 
 Try {
-    # Get High Performance plan GUID
-    $highPerf = powercfg -l | ForEach-Object{if($_.contains($POWERMANAGEMENT)) {$_.split()[3]}}
-    $currPlan = $(powercfg -getactivescheme).split()[3]
-    
-    # Switch to High Performance if not already active
-    if ($currPlan -ne $highPerf) {
-        powercfg -setactive $highPerf
-        Write-Host "[POWER] Switched to High Performance plan" -ForegroundColor Green
+    # Get High Performance plan GUID. On Win11 Home / certain SKUs the plan
+    # isn't pre-installed; we duplicate from the well-known builtin GUID if so.
+    $builtinHighPerf = '8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c'
+    $highPerf = powercfg -l | ForEach-Object { if ($_.contains($POWERMANAGEMENT)) { $_.split()[3] } } | Select-Object -First 1
+    if (-not $highPerf) {
+        Write-Host "[POWER] High Performance plan not present; creating from builtin..." -ForegroundColor Yellow
+        $dup = powercfg -duplicatescheme $builtinHighPerf 2>&1
+        if ($dup -match '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})') {
+            $highPerf = $matches[1]
+        }
+    }
+    if (-not $highPerf) {
+        Write-Warning "Could not locate or create a High Performance plan. Skipping plan switch."
     } else {
-        Write-Host "[POWER] Already using High Performance plan" -ForegroundColor Gray
+        $currPlan = $(powercfg -getactivescheme).split()[3]
+        if ($currPlan -ne $highPerf) {
+            powercfg -setactive $highPerf
+            Write-Host "[POWER] Switched to High Performance plan" -ForegroundColor Green
+        } else {
+            Write-Host "[POWER] Already using High Performance plan" -ForegroundColor Gray
+        }
     }
     
     # Get the active scheme GUID for modification

--- a/includes/Set-VolumeLabel-C.ps1
+++ b/includes/Set-VolumeLabel-C.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Set-VolumeLabel-C') { return }
+
 # Set volume label of C: to OS
 try {
     $vol = Get-CimInstance -ClassName Win32_Volume -Filter "DriveLetter='C:'"

--- a/includes/Shared-Functions.ps1
+++ b/includes/Shared-Functions.ps1
@@ -16,6 +16,29 @@ function Write-Log {
     }
 }
 
+function Test-MachineWideSentinel {
+    # Per-run sentinel for machine-wide includes that would otherwise re-run
+    # once per user-hive iteration of the orchestrator. Returns $true if the
+    # caller has already run this customize session and should bail out;
+    # returns $false the first time and drops a marker so subsequent calls
+    # exit early.
+    #
+    # customize-windows-client.ps1 sweeps C:\Temp\*.session at startup so a
+    # new customize run gets a clean slate.
+    #
+    # Usage at top of include:
+    #   if (Test-MachineWideSentinel -Name 'Disable-Bing-Search') { return }
+    param([Parameter(Mandatory)][string]$Name)
+    $dir = 'C:\Temp'
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -Path $dir -ItemType Directory -Force | Out-Null
+    }
+    $path = Join-Path $dir "$Name.session"
+    if (Test-Path -LiteralPath $path) { return $true }
+    New-Item -Path $path -ItemType File -Force | Out-Null
+    return $false
+}
+
 function Set-RegistryValue {
     param(
         [Parameter(Mandatory)][string]$Path,

--- a/includes/Show-Recently-Shortcuts.ps1
+++ b/includes/Show-Recently-Shortcuts.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Show-Recently-Shortcuts') { return }
+
 # Show recently and frequently used item shortcuts in Explorer
 $explorerPolicyPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer"
 if (!(Test-Path $explorerPolicyPath)) {

--- a/includes/Show-Small-Icons-in-Taskbar.ps1
+++ b/includes/Show-Small-Icons-in-Taskbar.ps1
@@ -1,2 +1,4 @@
+if (Test-MachineWideSentinel -Name 'Show-Small-Icons-in-Taskbar') { return }
+
 # Show small icons in taskbar
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "TaskbarSmallIcons" -Value 1 -Type "DWord" -Force

--- a/includes/Show-Task-View-Button.ps1
+++ b/includes/Show-Task-View-Button.ps1
@@ -1,2 +1,4 @@
+if (Test-MachineWideSentinel -Name 'Show-Task-View-Button') { return }
+
 # Show Task View button for all users via policy
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -Name "ShowTaskViewButton" -Value 1 -Type "DWord" -Force

--- a/includes/Uninstall-Default-Software-Packages.ps1
+++ b/includes/Uninstall-Default-Software-Packages.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Uninstall-Default-Software-Packages') { return }
+
 # Disable Consumer Features to prevent automatic installation of third-party apps and games
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CloudContent" -Name "DisableWindowsConsumerFeatures" -Value 1 -Type "DWord" -Force
 Write-Host "[OK] Disabled Windows Consumer Features (prevents automatic app installs)"
@@ -215,4 +217,3 @@ foreach ($pkg in $SoftwarePackages) {
 }
 
 Write-Host "[COMPLETED] App removal process finished" -ForegroundColor Green
-

--- a/includes/Uninstall-OneDrive.ps1
+++ b/includes/Uninstall-OneDrive.ps1
@@ -1,3 +1,5 @@
+if (Test-MachineWideSentinel -Name 'Uninstall-OneDrive') { return }
+
 # Remove OneDrive - Comprehensive removal with fallback disable
 
 Write-Host "[INFO] Starting OneDrive removal process..." -ForegroundColor Cyan
@@ -93,7 +95,7 @@ if ($onedriveInstalled) {
     # Remove Start Menu shortcuts created by OneDrive
     Write-Host "[INFO] Cleaning up OneDrive Start Menu shortcuts..."
 
-    $commonStartMenu = Join-Path $env:ProgramData 'Microsoft\\Windows\\Start Menu\\Programs'
+    $commonStartMenu = Join-Path $env:ProgramData 'Microsoft\Windows\Start Menu\Programs'
     if (Test-Path $commonStartMenu) {
         Get-ChildItem -Path $commonStartMenu -Filter 'OneDrive*.lnk' -ErrorAction SilentlyContinue | ForEach-Object {
             try {
@@ -106,7 +108,7 @@ if ($onedriveInstalled) {
     }
 
     foreach ($profile in $profiles) {
-        $userStartMenu = Join-Path $profile.FullName 'AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs'
+        $userStartMenu = Join-Path $profile.FullName 'AppData\Roaming\Microsoft\Windows\Start Menu\Programs'
         if (Test-Path $userStartMenu) {
             Get-ChildItem -Path $userStartMenu -Filter 'OneDrive*.lnk' -ErrorAction SilentlyContinue | ForEach-Object {
                 try {


### PR DESCRIPTION
## Summary
PR #221's batch sentinel injection used \`echo \"\$original\"\` in bash, which expanded \`\$(\$hive.PSChildName)\` inside \`Disable-XBox.ps1\` as a command substitution. Result: file truncated at line 12 with \"missing terminator\" PowerShell error every customize run.

Restored the file from main and re-prepended the sentinel via \`cat\` so no shell expansion happens.

Verified \`diff <(git show main:includes/Disable-XBox.ps1) <(tail -n +3 includes/Disable-XBox.ps1)\` is empty — content matches main exactly.

Also confirmed via wc/diff that no other sentinelled include suffered the same fate (they had no \`\$()\` constructs).

## Test plan
- [ ] Re-run customize via SuperOps; \`Execute Disable-XBox.ps1 ...\` no longer prints the parser error.
- [ ] GameDVR registry values still set on first iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)