### PR TITLE
Actually restore Disable-XBox.ps1 (third attempt)

### DIFF
--- a/includes/Disable-XBox.ps1
+++ b/includes/Disable-XBox.ps1
@@ -9,4 +9,13 @@ Get-AppxPackage "Microsoft.Xbox.TCUI" | Remove-AppxPackage
 # Apply system-wide policy to disable Game DVR
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\GameDVR" -Name "AllowGameDVR" -Value 0 -Type "DWord"
 Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR" -Name "value" -Value 0 -Type "DWord"
-Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager
+Set-RegistryValue -Path "HKLM:\SOFTWARE\Microsoft\PolicyManager\current\ApplicationManagement\AllowGameDVR" -Name "value" -Value 0 -Type "DWord"
+
+# Clean up any per-user Game DVR settings
+$hives = Get-ChildItem 'Registry::HKEY_USERS' | Where-Object { $_.PSChildName -match '^S-1-5-' -and $_.PSChildName -notmatch '_Classes$' }
+foreach ($hive in $hives) {
+    $userPath = "Registry::$($hive.PSChildName)\System\GameConfigStore"
+    Remove-RegistryValue -Path $userPath -Name 'GameDVR_Enabled'
+}
+
+Remove-RegistryValue -Path 'HKU:\.DEFAULT\System\GameConfigStore' -Name 'GameDVR_Enabled'


### PR DESCRIPTION
PR #222 didn't take. GitHub's squash-merge three-way-merged the broken main version with the branch and kept the broken one. This PR is rebased directly onto current main so the diff is unambiguous: replace 11 truncated lines with the correct 21-line file.

Verified locally:
\`\`\`
$ wc -l includes/Disable-XBox.ps1
21 includes/Disable-XBox.ps1
$ git diff main -- includes/Disable-XBox.ps1
[shows the 10 lines being restored]
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)