### PR TITLE
Parse Get-ComputerRestorePoint CIM datetime correctly

### DIFF
--- a/customize-windows-client.ps1
+++ b/customize-windows-client.ps1
@@ -110,15 +110,23 @@ try {
 
     # Skip if a recent restore point already exists (5-min window matches the
     # throttle above). Saves time on repeated runs and avoids stalls.
+    # Get-ComputerRestorePoint returns CreationTime as a WMI CIM datetime
+    # string (yyyyMMddHHmmss.ffffff-ZZZ), not a .NET DateTime — convert it
+    # via ManagementDateTimeConverter.
     $recent = Get-ComputerRestorePoint -ErrorAction SilentlyContinue |
         Sort-Object -Property CreationTime -Descending |
         Select-Object -First 1
     $skipRestore = $false
     if ($recent) {
-        $elapsedMin = (New-TimeSpan -Start $recent.CreationTime -End (Get-Date)).TotalMinutes
-        if ($elapsedMin -lt 5) {
-            Write-Host "[INFO] Restore point already exists from $([math]::Round($elapsedMin,1)) min ago; reusing." -ForegroundColor DarkGray
-            $skipRestore = $true
+        try {
+            $recentTime = [Management.ManagementDateTimeConverter]::ToDateTime($recent.CreationTime)
+            $elapsedMin = (New-TimeSpan -Start $recentTime -End (Get-Date)).TotalMinutes
+            if ($elapsedMin -lt 5) {
+                Write-Host "[INFO] Restore point already exists from $([math]::Round($elapsedMin,1)) min ago; reusing." -ForegroundColor DarkGray
+                $skipRestore = $true
+            }
+        } catch {
+            Write-Warning "Could not parse existing restore-point CreationTime ('$($recent.CreationTime)'); proceeding to create a new one."
         }
     }
 


### PR DESCRIPTION
\`Get-ComputerRestorePoint\` returns \`CreationTime\` as a WMI CIM datetime string (\`yyyyMMddHHmmss.ffffff-ZZZ\`), not a .NET DateTime. PR #224's \`New-TimeSpan\` failed to coerce it, breaking the skip-if-recent check and surfacing as:

\`\`\`
Restore point: Cannot bind parameter 'Start'. Cannot convert value
"20260528114621.957155-000" to type "System.DateTime".
\`\`\`

Fix: use \`[Management.ManagementDateTimeConverter]::ToDateTime()\` to convert the CIM string, wrapped in try/catch so an unparseable value falls through to creating a fresh restore point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)