### PR TITLE
Remove dead duplicate sentinel in AA-Apply

### DIFF
--- a/includes/AA-Apply-HardenSystemSecurity.ps1
+++ b/includes/AA-Apply-HardenSystemSecurity.ps1
@@ -28,15 +28,6 @@ $StateKey   = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
 $StoreId    = '9p7ggfl7dx57'
 $PkgFamily  = 'VioletHansen.HardenSystemSecurity_ea7andspwdn10'
 $PkgName    = 'VioletHansen.HardenSystemSecurity'
-$SessionSentinel = 'C:\Temp\AA-Apply-HardenSystemSecurity.session'
-
-# Orchestrator re-invokes each include once per user hive. This script is
-# machine-wide — only run it the first time. Use a sentinel file rooted in
-# the customize-run's working directory so it auto-clears between runs.
-if (Test-Path -LiteralPath $SessionSentinel) {
-    return
-}
-New-Item -Path $SessionSentinel -ItemType File -Force | Out-Null
 
 if (-not (Test-Path -LiteralPath $ReportFile)) {
     Write-Log "ERROR: Harden System Security report not found at $ReportFile"


### PR DESCRIPTION
PR #221 left both a Test-MachineWideSentinel call and the original hand-rolled sentinel block in AA-Apply-HardenSystemSecurity. Both pointed at the same marker file, so the helper would create the marker and the hand-rolled check on the very next line would see it and return immediately.

Effect: the apply step has been silently no-op'ing on every customize run since PR #221. HSS detection, ImportReport, and registry state-tracking have never actually executed. The expected \`[SKIP] Harden System Security not installed yet\` and \`[INFO] Importing report ...\` lines were never produced because the function returned before reaching them.

Fix: remove the duplicate block. Helper at the top is enough; orchestrator already clears \`*.session\` at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)