### PR TITLE
Apply HSS report via elevated scheduled task (fixes SYSTEM exit 1)

### DIFF
--- a/Ensure-Apps.ps1
+++ b/Ensure-Apps.ps1
@@ -7,6 +7,9 @@
 # - Registers a per-user scheduled task that installs msstore / per-user apps
 #   (Harden System Security) at logon and daily, in the user's context where
 #   `winget --source msstore` actually works.
+# - Registers an admin-elevated scheduled task that applies the HSS report
+#   (HardenSystemSecurity.exe needs UAC + interactive desktop, which SYSTEM
+#   session 0 can't provide).
 # - Writes status flags under HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps for a
 #   companion Verify-Apps.ps1 to alert on.
 #
@@ -14,8 +17,9 @@
 
 [CmdletBinding()]
 param(
-    [string] $TaskPath = '\CustomizeWindowsSetup\',
-    [string] $TaskName = 'Install-UserApps'
+    [string] $TaskPath        = '\CustomizeWindowsSetup\',
+    [string] $InstallTaskName = 'Install-UserApps',
+    [string] $ApplyTaskName   = 'Apply-HardenSystemSecurityReport'
 )
 
 $ErrorActionPreference = 'Continue'  # never block the rest of the script
@@ -175,20 +179,154 @@ foreach (`$app in `$apps) {
         -StartWhenAvailable -MultipleInstances IgnoreNew `
         -ExecutionTimeLimit (New-TimeSpan -Hours 1)
 
-    $existing = Get-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName -ErrorAction SilentlyContinue
+    $existing = Get-ScheduledTask -TaskPath $TaskPath -TaskName $InstallTaskName -ErrorAction SilentlyContinue
     if ($existing) {
-        Unregister-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName -Confirm:$false
+        Unregister-ScheduledTask -TaskPath $TaskPath -TaskName $InstallTaskName -Confirm:$false
     }
     Register-ScheduledTask `
-        -TaskPath $TaskPath -TaskName $TaskName `
+        -TaskPath $TaskPath -TaskName $InstallTaskName `
         -Action $action -Trigger @($logon, $daily) `
         -Principal $principal -Settings $settings `
         -Description 'CustomizeWindowsSetup: installs per-user MS Store / msstore-source apps for the logged-in user. Idempotent. Logon + daily 03:00.' | Out-Null
 
-    Write-AppLog "Scheduled task registered: $TaskPath$TaskName (payload: $payloadPath)"
+    Write-AppLog "Scheduled task registered: $TaskPath$InstallTaskName (payload: $payloadPath)"
     Set-AppState -Key 'UserAppsTask' -Name 'Registered'  -Value 1                            -Type 'DWord'
     Set-AppState -Key 'UserAppsTask' -Name 'PayloadPath' -Value $payloadPath                 -Type 'String'
     Set-AppState -Key 'UserAppsTask' -Name 'RegisteredUtc' -Value (Get-Date).ToUniversalTime().ToString('o') -Type 'String'
+}
+
+# --- Step 4: register admin-elevated apply task for HSS report -------------
+function Register-ApplyHssTask {
+    # Payload script — runs in an admin user's session (NO UAC prompt because
+    # task is registered with RunLevel Highest). Reads staged report from
+    # ProgramData, hash-checks vs HKLM, applies via HSS.exe if needed, writes
+    # detailed status back to HKLM for Verify-Apps to read.
+    $payload = @'
+$ErrorActionPreference = 'Continue'
+$report   = 'C:\ProgramData\CustomizeWindowsSetup\Harden-System-Security.report.json'
+$stateKey = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
+$log      = 'C:\Temp\Apply-HardenSystemSecurityReport.log'
+$pkgName  = 'VioletHansen.HardenSystemSecurity'
+
+function Log($m) {
+    if (-not (Test-Path 'C:\Temp')) { New-Item 'C:\Temp' -ItemType Directory -Force | Out-Null }
+    Add-Content -Path $log -Value "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] [$env:USERNAME] $m"
+}
+function SetState($name, $value, $type = 'String') {
+    if (-not (Test-Path $stateKey)) { New-Item -Path $stateKey -Force | Out-Null }
+    New-ItemProperty -Path $stateKey -Name $name -Value $value -PropertyType $type -Force | Out-Null
+}
+
+Log "Apply task fired."
+
+if (-not (Test-Path -LiteralPath $report)) {
+    Log "No staged report at $report; nothing to apply."
+    return
+}
+
+$currentHash = (Get-FileHash -LiteralPath $report -Algorithm SHA256).Hash
+$storedHash  = (Get-ItemProperty -Path $stateKey -Name 'ReportHash' -ErrorAction SilentlyContinue).ReportHash
+$storedStat  = (Get-ItemProperty -Path $stateKey -Name 'LastAppliedStatus' -ErrorAction SilentlyContinue).LastAppliedStatus
+
+if ($currentHash -eq $storedHash -and $storedStat -eq 'success') {
+    Log "Hash matches ($($currentHash.Substring(0,12))...) and last status is success; skip."
+    return
+}
+
+$pkg = Get-AppxPackage -AllUsers -Name $pkgName -ErrorAction SilentlyContinue |
+    Sort-Object Version -Descending | Select-Object -First 1
+if (-not $pkg) {
+    Log "HSS package not installed yet; will retry next trigger."
+    SetState 'LastAppliedStatus' 'pending-install'
+    SetState 'LastAttemptUtc'    (Get-Date).ToUniversalTime().ToString('o')
+    return
+}
+
+$exe = $null
+foreach ($name in 'HardenSystemSecurity.exe','HSS.exe') {
+    $p = Join-Path $pkg.InstallLocation $name
+    if (Test-Path -LiteralPath $p) { $exe = $p; break }
+}
+if (-not $exe) {
+    Log "Binary not found in $($pkg.InstallLocation)."
+    SetState 'LastAppliedStatus' 'binary-missing'
+    SetState 'LastAttemptUtc'    (Get-Date).ToUniversalTime().ToString('o')
+    return
+}
+
+Log "Applying via $exe (hash $($currentHash.Substring(0,12))..., HSS v$($pkg.Version))."
+SetState 'LastAppliedStatus' 'in-progress'
+SetState 'LastAttemptUtc'    (Get-Date).ToUniversalTime().ToString('o')
+
+$proc = Start-Process -FilePath $exe `
+    -ArgumentList @('--cli','ImportReport',"--in=$report",'--mode=full') `
+    -PassThru -Wait -WindowStyle Hidden -ErrorAction SilentlyContinue
+
+if (-not $proc) {
+    Log "Start-Process returned null."
+    SetState 'LastAppliedStatus'   'launch-failed'
+    SetState 'LastAppliedExitCode' -1 'DWord'
+    return
+}
+
+$exit = $proc.ExitCode
+SetState 'LastAppliedExitCode' $exit 'DWord'
+
+if ($exit -eq 0) {
+    SetState 'ReportHash'        $currentHash
+    SetState 'ReportPath'        $report
+    SetState 'LastAppliedUtc'    (Get-Date).ToUniversalTime().ToString('o')
+    SetState 'AppliedHssVersion' $pkg.Version.ToString()
+    SetState 'LastAppliedStatus' 'success'
+    Log "Apply succeeded."
+} else {
+    SetState 'LastAppliedStatus' 'failed'
+    Log "Apply failed (exit $exit)."
+}
+'@
+
+    $payloadDir  = Join-Path $env:ProgramData 'CustomizeWindowsSetup'
+    if (-not (Test-Path $payloadDir)) { New-Item -Path $payloadDir -ItemType Directory -Force | Out-Null }
+    $payloadPath = Join-Path $payloadDir 'Apply-HardenSystemSecurityReport.task.ps1'
+    Set-Content -Path $payloadPath -Value $payload -Encoding UTF8 -Force
+
+    $action = New-ScheduledTaskAction `
+        -Execute 'powershell.exe' `
+        -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$payloadPath`""
+
+    # Logon trigger delayed 5 min so the Install-UserApps task (2 min delay)
+    # has a chance to install HSS first when both fire from the same logon.
+    $logon = New-ScheduledTaskTrigger -AtLogOn
+    $logon.Delay = 'PT5M'
+    # Daily at 04:00 so it lands after the 03:00 install task.
+    $daily = New-ScheduledTaskTrigger -Daily -At 4am
+
+    # Principal = local Administrators group, RunLevel Highest.
+    # Task fires for any signed-in admin user with full elevation — no UAC.
+    $principal = New-ScheduledTaskPrincipal `
+        -GroupId 'S-1-5-32-544' `
+        -RunLevel Highest
+
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable -MultipleInstances IgnoreNew `
+        -Hidden `
+        -ExecutionTimeLimit (New-TimeSpan -Hours 1)
+
+    $existing = Get-ScheduledTask -TaskPath $TaskPath -TaskName $ApplyTaskName -ErrorAction SilentlyContinue
+    if ($existing) {
+        Unregister-ScheduledTask -TaskPath $TaskPath -TaskName $ApplyTaskName -Confirm:$false
+    }
+    Register-ScheduledTask `
+        -TaskPath $TaskPath -TaskName $ApplyTaskName `
+        -Action $action -Trigger @($logon, $daily) `
+        -Principal $principal -Settings $settings `
+        -Description 'CustomizeWindowsSetup: applies the staged HSS hardening report via HardenSystemSecurity.exe in an elevated admin user session. Idempotent.' | Out-Null
+
+    Write-AppLog "Scheduled task registered: $TaskPath$ApplyTaskName (payload: $payloadPath)"
+    Set-AppState -Key 'ApplyHssTask' -Name 'Registered'    -Value 1                                                -Type 'DWord'
+    Set-AppState -Key 'ApplyHssTask' -Name 'PayloadPath'   -Value $payloadPath                                     -Type 'String'
+    Set-AppState -Key 'ApplyHssTask' -Name 'RegisteredUtc' -Value (Get-Date).ToUniversalTime().ToString('o')       -Type 'String'
 }
 
 # --- Run -------------------------------------------------------------------
@@ -196,6 +334,7 @@ Write-AppLog '--- Ensure-Apps.ps1 starting ---'
 Ensure-Winget
 foreach ($app in $MachineApps) { Install-MachineApp -App $app }
 Register-UserAppsTask
+Register-ApplyHssTask
 Set-AppState -Key 'Bootstrap' -Name 'LastRunUtc' -Value (Get-Date).ToUniversalTime().ToString('o') -Type 'String'
 Write-AppLog '--- Ensure-Apps.ps1 finished ---'
 Write-Host '[SUCCESS] Ensure-Apps complete. See HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps for status.' -ForegroundColor Green

--- a/Verify-Apps.ps1
+++ b/Verify-Apps.ps1
@@ -1,10 +1,10 @@
 # Verify-Apps.ps1
 #
 # SuperOps monitor companion to Ensure-Apps.ps1.
-# Reads HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps status flags AND re-checks
-# each app's actual presence. Prints a one-line status per app and exits
-# non-zero if anything is missing — schedule this in SuperOps to get alerts
-# when an endpoint drifts.
+# Reads HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps state AND re-checks each
+# app's actual presence. Prints one line per check and exits non-zero if
+# anything looks wrong — schedule this in SuperOps to get alerts when an
+# endpoint drifts.
 
 $ErrorActionPreference = 'Continue'
 
@@ -24,18 +24,62 @@ foreach ($c in $Checks) {
     if (-not $present) { $bad++ }
 }
 
-# Bonus: surface HSS report state from AA-Apply-HardenSystemSecurity.ps1.
-$hssKey = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
-if (Test-Path $hssKey) {
-    $applied = (Get-ItemProperty -Path $hssKey -ErrorAction SilentlyContinue).LastAppliedUtc
-    Write-Host "INFO    HSS report last applied: $applied"
+# --- HSS hardening health -------------------------------------------------
+# Three dimensions: status, staleness, drift.
+
+$hssKey       = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
+$stagedReport = 'C:\ProgramData\CustomizeWindowsSetup\Harden-System-Security.report.json'
+$state        = if (Test-Path $hssKey) { Get-ItemProperty -Path $hssKey -ErrorAction SilentlyContinue } else { $null }
+
+if (-not $state -or -not $state.LastAppliedStatus) {
+    Write-Host 'WARN    HSS report: never applied'
+    $bad++
 } else {
-    Write-Host 'INFO    HSS report has never been applied.'
+    switch ($state.LastAppliedStatus) {
+        'success' {
+            Write-Host "OK      HSS apply status: success (exit $($state.LastAppliedExitCode), HSS v$($state.AppliedHssVersion))"
+        }
+        'pending-install' {
+            Write-Host "WARN    HSS apply status: waiting for HSS package to install"
+            $bad++
+        }
+        default {
+            Write-Host "FAIL    HSS apply status: $($state.LastAppliedStatus) (last exit $($state.LastAppliedExitCode))"
+            $bad++
+        }
+    }
+}
+
+# Staleness: apply older than 30 days = something's wrong
+if ($state -and $state.LastAppliedUtc) {
+    try {
+        $applied = [DateTime]::Parse($state.LastAppliedUtc).ToUniversalTime()
+        $ageDays = (New-TimeSpan -Start $applied -End ([DateTime]::UtcNow)).TotalDays
+        if ($ageDays -gt 30) {
+            Write-Host "WARN    HSS report stale: applied $([math]::Round($ageDays)) days ago ($($state.LastAppliedUtc))"
+            $bad++
+        } else {
+            Write-Host "INFO    HSS report last applied: $($state.LastAppliedUtc) ($([math]::Round($ageDays,1)) days ago)"
+        }
+    } catch {
+        Write-Host "INFO    HSS report last applied: $($state.LastAppliedUtc) (could not parse)"
+    }
+}
+
+# Drift: staged report on disk differs from what HKLM says was applied
+if (Test-Path -LiteralPath $stagedReport) {
+    $stagedHash = (Get-FileHash -LiteralPath $stagedReport -Algorithm SHA256).Hash
+    if ($state -and $state.ReportHash) {
+        if ($stagedHash -ne $state.ReportHash) {
+            Write-Host "WARN    HSS report drift: staged hash $($stagedHash.Substring(0,12))... differs from applied $($state.ReportHash.Substring(0,12))..."
+            $bad++
+        }
+    }
 }
 
 if ($bad -gt 0) {
-    Write-Host "[FAIL] $bad item(s) missing." -ForegroundColor Red
+    Write-Host "[FAIL] $bad issue(s)." -ForegroundColor Red
     exit 1
 }
-Write-Host '[OK] All apps present.' -ForegroundColor Green
+Write-Host '[OK] All checks pass.' -ForegroundColor Green
 exit 0

--- a/includes/AA-Apply-HardenSystemSecurity.ps1
+++ b/includes/AA-Apply-HardenSystemSecurity.ps1
@@ -1,134 +1,58 @@
-# Applies a Harden System Security report (HotCakeX/Harden-Windows-Security)
-# as the very first customization step. Designed to run on a schedule.
+# Stages the Harden System Security report and triggers the per-user apply
+# task. This file runs under SYSTEM (session 0) where HSS.exe CANNOT run —
+# the packaged WinUI app needs an interactive desktop + UAC elevation, and
+# session 0 has neither. So instead we:
 #
-# Documented mechanism (see HSS wiki):
-#   HSS.exe --cli ImportReport --in=<file> --mode=full
-#   "Import and apply a previously exported system state report. Elevation
-#    is required. full -> apply all measures marked applied AND remove all
-#    measures marked not applied."
+#   1. Copy the bundled report into C:\ProgramData\CustomizeWindowsSetup\
+#      where the task (running in an admin user's session) can read it.
+#   2. Start the scheduled task `\CustomizeWindowsSetup\Apply-HardenSystemSecurityReport`
+#      (registered by Ensure-Apps.ps1) which actually invokes HSS.exe with
+#      ImportReport. If an admin is logged in, it runs immediately; if not,
+#      it's queued for the next logon trigger.
 #
-# Execution context:
-#   - Safe to run as SYSTEM (SuperOps default) OR as an interactive admin.
-#   - HSS is a Microsoft Store app. The 'HSS.exe' alias documented in the wiki
-#     is a per-user AppExecutionAlias that does NOT resolve under SYSTEM. We
-#     locate the actual binary (HardenSystemSecurity.exe, or HSS.exe if the
-#     install ever ships it) via Get-AppxPackage -AllUsers.
-#   - Installation: winget `--source msstore` is unreliable under SYSTEM.
-#     This script will only attempt winget when run interactively. Under SYSTEM
-#     the app must be pre-installed (Store, or one-off user-context winget).
-#
-# Re-run policy:
-#   SHA-256 of the report is recorded at
-#     HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity\ReportHash
-#   Same hash -> skip. Different/missing -> apply and update. To force a
-#   re-apply on the next run, delete that registry value.
+# The task does its own hash check against
+#   HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity\ReportHash
+# so re-staging the same report is a sub-second no-op.
 
 if (Test-MachineWideSentinel -Name 'AA-Apply-HardenSystemSecurity') { return }
 
-$ReportFile = Join-Path $PSScriptRoot 'Harden-System-Security.report.json'
-$StateKey   = 'HKLM:\SOFTWARE\CustomizeWindowsSetup\HardenSystemSecurity'
-$StoreId    = '9p7ggfl7dx57'
-$PkgFamily  = 'VioletHansen.HardenSystemSecurity_ea7andspwdn10'
-$PkgName    = 'VioletHansen.HardenSystemSecurity'
+$SourceReport = Join-Path $PSScriptRoot 'Harden-System-Security.report.json'
+$StageDir     = Join-Path $env:ProgramData 'CustomizeWindowsSetup'
+$StagedReport = Join-Path $StageDir 'Harden-System-Security.report.json'
+$TaskPath     = '\CustomizeWindowsSetup\'
+$TaskName     = 'Apply-HardenSystemSecurityReport'
 
-if (-not (Test-Path -LiteralPath $ReportFile)) {
-    Write-Log "ERROR: Harden System Security report not found at $ReportFile"
-    Write-Host "[ERROR] Report file missing: $ReportFile" -ForegroundColor Red
+if (-not (Test-Path -LiteralPath $SourceReport)) {
+    Write-Log "ERROR: Harden System Security report not found at $SourceReport"
+    Write-Host "[ERROR] Report file missing: $SourceReport" -ForegroundColor Red
     return
 }
 
-function Test-IsSystem {
-    ([Security.Principal.WindowsIdentity]::GetCurrent()).User.Value -eq 'S-1-5-18'
+try {
+    if (-not (Test-Path -LiteralPath $StageDir)) {
+        New-Item -Path $StageDir -ItemType Directory -Force | Out-Null
+    }
+    Copy-Item -LiteralPath $SourceReport -Destination $StagedReport -Force
+    Write-Host "[INFO] Staged HSS report at $StagedReport" -ForegroundColor DarkGray
+    Write-Log "Staged HSS report at $StagedReport for the apply task."
+} catch {
+    Write-Log "ERROR: Failed to stage HSS report - $_"
+    Write-Host "[ERROR] Failed to stage HSS report: $_" -ForegroundColor Red
+    return
 }
 
-function Resolve-HssExe {
-    # Look up the installed Appx package across all users, then point at the
-    # actual binary inside its InstallLocation. The HSS wiki documents the
-    # entrypoint as 'HSS.exe' — that's the per-user AppExecutionAlias, which
-    # does NOT resolve under SYSTEM. The real binary in the WindowsApps folder
-    # is 'HardenSystemSecurity.exe'. Try the alias first (future-proof) then
-    # the real name.
-    $pkg = Get-AppxPackage -AllUsers -Name $PkgName -ErrorAction SilentlyContinue |
-        Sort-Object -Property Version -Descending |
-        Select-Object -First 1
-    if (-not $pkg) { return $null }
-    foreach ($candidate in 'HSS.exe','HardenSystemSecurity.exe') {
-        $exe = Join-Path $pkg.InstallLocation $candidate
-        if (Test-Path -LiteralPath $exe) { return $exe }
-    }
-    return $null
-}
-
-function Install-Hss {
-    if (Test-IsSystem) {
-        throw @"
-Harden System Security is not installed and this script is running as SYSTEM.
-Microsoft Store installs via winget are unreliable under SYSTEM. Install once
-in an interactive admin context with:
-
-    winget install --id $StoreId --exact --source msstore ``
-        --accept-package-agreements --accept-source-agreements
-
-or via the Store: https://apps.microsoft.com/detail/$StoreId
-Then re-run this script.
-"@
-    }
-    Write-Host '[INFO] Installing Harden System Security from Microsoft Store...' -ForegroundColor Cyan
-    if (-not (Get-Command 'winget.exe' -ErrorAction SilentlyContinue)) {
-        throw 'winget is not available. Install "App Installer" from the Microsoft Store and re-run.'
-    }
-    & winget install --id $StoreId --exact `
-        --accept-package-agreements --accept-source-agreements `
-        --source msstore | Out-Host
-    if ($LASTEXITCODE -ne 0) {
-        throw "winget install failed with exit code $LASTEXITCODE."
-    }
-}
-
-function Invoke-Hss {
-    param([Parameter(Mandatory)][string]$Exe, [Parameter(Mandatory)][string[]]$Arguments)
-    Write-Host "[INFO] $Exe $($Arguments -join ' ')" -ForegroundColor DarkCyan
-    & $Exe @Arguments
-    if ($LASTEXITCODE -ne 0) {
-        throw "HSS.exe exited with code $LASTEXITCODE."
-    }
+$task = Get-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName -ErrorAction SilentlyContinue
+if (-not $task) {
+    Write-Host "[WARN] Scheduled task $TaskPath$TaskName not registered. Run Ensure-Apps.ps1 first." -ForegroundColor Yellow
+    Write-Log "Apply task not registered; cannot trigger HSS apply."
+    return
 }
 
 try {
-    $currentHash = (Get-FileHash -LiteralPath $ReportFile -Algorithm SHA256).Hash
-    $storedHash  = $null
-    if (Test-Path -LiteralPath $StateKey) {
-        $storedHash = (Get-ItemProperty -Path $StateKey -Name 'ReportHash' -ErrorAction SilentlyContinue).ReportHash
-    }
-
-    if ($storedHash -eq $currentHash) {
-        Write-Host "[INFO] Harden System Security report unchanged (hash $($currentHash.Substring(0,12))...); skipping." -ForegroundColor DarkGray
-        return
-    }
-
-    $hss = Resolve-HssExe
-    if (-not $hss) {
-        if (Test-IsSystem) {
-            Write-Host '[SKIP] Harden System Security not installed yet (waiting for user-logon install task to fire). Will apply on a later run.' -ForegroundColor Yellow
-            Write-Log 'Harden System Security: skipped — package not yet installed under SYSTEM context.'
-            return
-        }
-        Install-Hss
-        $hss = Resolve-HssExe
-        if (-not $hss) { throw 'HSS.exe still not found after install attempt.' }
-    }
-    Write-Host "[INFO] Using HSS.exe at: $hss" -ForegroundColor DarkGray
-
-    Write-Host "[INFO] Importing report '$ReportFile' (mode=full)..." -ForegroundColor Cyan
-    Invoke-Hss -Exe $hss -Arguments @('--cli', 'ImportReport', "--in=$ReportFile", '--mode=full')
-    Write-Log "Harden System Security: imported report from $ReportFile in mode=full (hash $currentHash)."
-
-    Set-RegistryValue -Path $StateKey -Name 'ReportHash'     -Value $currentHash                               -Type 'String' -Force
-    Set-RegistryValue -Path $StateKey -Name 'ReportPath'     -Value $ReportFile                                -Type 'String' -Force
-    Set-RegistryValue -Path $StateKey -Name 'LastAppliedUtc' -Value (Get-Date).ToUniversalTime().ToString('o') -Type 'String' -Force
-
-    Write-Host '[SUCCESS] Harden System Security report applied.' -ForegroundColor Green
+    Start-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName
+    Write-Host "[OK] Triggered $TaskPath$TaskName — apply will run in the next admin user session." -ForegroundColor Green
+    Write-Log "Triggered $TaskPath$TaskName."
 } catch {
-    Write-Log "ERROR: Harden System Security apply failed - $_"
-    Write-Host "[ERROR] Harden System Security apply failed: $_" -ForegroundColor Red
+    Write-Log "ERROR: Failed to trigger $TaskPath$TaskName - $_"
+    Write-Host "[ERROR] Failed to trigger apply task: $_" -ForegroundColor Red
 }


### PR DESCRIPTION
## Summary
SuperOps's SYSTEM context (session 0) can't run \`HardenSystemSecurity.exe --cli ImportReport --mode=full\` because the packaged WinUI app needs both UAC elevation and an interactive desktop. The auto-relaunch-elevated step fails internally → exit code 1.

Confirmed by:
- Interactive elevated run as a normal admin user → exit 0, log shows full apply succeeding across BitLocker, LockScreen, UAC, DeviceGuard, Firewall, Networking, MiscellaneousConfigurations, WindowsUpdate categories.
- HSS wiki: exit 1 = "Unexpected runtime failure (exception during execution)".

## New design
| Component | What it does |
|---|---|
| \`Ensure-Apps.ps1\` (one-shot bootstrap, SYSTEM) | Registers a new \`\\CustomizeWindowsSetup\\Apply-HardenSystemSecurityReport\` task: BUILTIN\\Administrators, RunLevel Highest, Hidden, AtLogOn+5min + Daily 04:00 |
| \`includes/AA-Apply-HardenSystemSecurity.ps1\` (per customize run, SYSTEM) | Copies report to \`C:\\ProgramData\\CustomizeWindowsSetup\\\` and \`Start-ScheduledTask\`s the apply task. No longer calls HSS.exe directly. |
| Apply task payload (admin session, elevated, hidden window) | Hash-check; if differs OR last status != success → run HSS via \`Start-Process -WindowStyle Hidden -Wait\`; write status to HKLM |
| \`Verify-Apps.ps1\` | Adds three HSS dimensions: status, staleness (>30 days), drift (staged vs applied hash). Exits 1 on any issue. |

## Status fields in HKLM\\SOFTWARE\\CustomizeWindowsSetup\\HardenSystemSecurity
- \`ReportHash\` — SHA-256 of last successful apply
- \`ReportPath\` — staged report location
- \`LastAppliedUtc\` — ISO timestamp of last success
- \`LastAppliedStatus\` — \`success\` | \`failed\` | \`pending-install\` | \`binary-missing\` | \`launch-failed\` | \`in-progress\`
- \`LastAppliedExitCode\` — HSS.exe's exit code
- \`LastAttemptUtc\` — ISO timestamp of last attempt (success or fail)
- \`AppliedHssVersion\` — HSS version that did the apply

## UAC and console window
- UAC: gone. Scheduled task with \`RunLevel Highest\` runs already-elevated, Windows does not present UAC for task triggers.
- Console window: PowerShell wrapper is hidden (\`-WindowStyle Hidden\` + task \`Hidden=true\`). HSS.exe's own console may briefly flash — packaged-app behaviour, not suppressible without an upstream flag.

## Re-deploy steps
1. Push the updated \`Ensure-Apps.ps1\` from SuperOps once per endpoint — it overwrites both tasks idempotently.
2. Next customize run via SuperOps will use the new AA-Apply path: stages report, triggers task. Apply happens in the admin user's session.

## Test plan
- [ ] Run \`Ensure-Apps.ps1\` on the test endpoint — confirm \`\\CustomizeWindowsSetup\\Apply-HardenSystemSecurityReport\` registered.
- [ ] Run customize via SuperOps — AA-Apply prints \`[OK] Triggered\`.
- [ ] Within ~30s the task should fire (an admin is logged in) — confirm HKLM \`LastAppliedStatus=success\` and \`LastAppliedExitCode=0\`.
- [ ] Re-run customize — AA-Apply re-triggers but task sees hash matches and skips.
- [ ] Run Verify-Apps.ps1 — should print \`[OK] All checks pass.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)