### PR TITLE
Strip em-dashes that break PowerShell 5 parser

### DIFF
--- a/Ensure-Apps.ps1
+++ b/Ensure-Apps.ps1
@@ -70,7 +70,7 @@ function Ensure-Winget {
         return
     }
     # Provisioning the MSIX bundle works under SYSTEM (unlike `winget install`).
-    # If App Installer is missing, you typically need to download the bundle —
+    # If App Installer is missing, you typically need to download the bundle -
     # SuperOps users usually keep one cached. We try Get-AppxPackage first in
     # case it's installed but not on SYSTEM's PATH.
     $appx = Get-AppxPackage -AllUsers -Name 'Microsoft.DesktopAppInstaller' -ErrorAction SilentlyContinue
@@ -197,7 +197,7 @@ foreach (`$app in `$apps) {
 
 # --- Step 4: register admin-elevated apply task for HSS report -------------
 function Register-ApplyHssTask {
-    # Payload script — runs in an admin user's session (NO UAC prompt because
+    # Payload script - runs in an admin user's session (NO UAC prompt because
     # task is registered with RunLevel Highest). Reads staged report from
     # ProgramData, hash-checks vs HKLM, applies via HSS.exe if needed, writes
     # detailed status back to HKLM for Verify-Apps to read.
@@ -302,7 +302,7 @@ if ($exit -eq 0) {
     $daily = New-ScheduledTaskTrigger -Daily -At 4am
 
     # Principal = local Administrators group, RunLevel Highest.
-    # Task fires for any signed-in admin user with full elevation — no UAC.
+    # Task fires for any signed-in admin user with full elevation - no UAC.
     $principal = New-ScheduledTaskPrincipal `
         -GroupId 'S-1-5-32-544' `
         -RunLevel Highest

--- a/Verify-Apps.ps1
+++ b/Verify-Apps.ps1
@@ -3,7 +3,7 @@
 # SuperOps monitor companion to Ensure-Apps.ps1.
 # Reads HKLM:\SOFTWARE\CustomizeWindowsSetup\Apps state AND re-checks each
 # app's actual presence. Prints one line per check and exits non-zero if
-# anything looks wrong — schedule this in SuperOps to get alerts when an
+# anything looks wrong - schedule this in SuperOps to get alerts when an
 # endpoint drifts.
 
 $ErrorActionPreference = 'Continue'

--- a/includes/AA-Apply-HardenSystemSecurity.ps1
+++ b/includes/AA-Apply-HardenSystemSecurity.ps1
@@ -1,5 +1,5 @@
 # Stages the Harden System Security report and triggers the per-user apply
-# task. This file runs under SYSTEM (session 0) where HSS.exe CANNOT run —
+# task. This file runs under SYSTEM (session 0) where HSS.exe CANNOT run -
 # the packaged WinUI app needs an interactive desktop + UAC elevation, and
 # session 0 has neither. So instead we:
 #
@@ -50,7 +50,7 @@ if (-not $task) {
 
 try {
     Start-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName
-    Write-Host "[OK] Triggered $TaskPath$TaskName — apply will run in the next admin user session." -ForegroundColor Green
+    Write-Host "[OK] Triggered $TaskPath$TaskName - apply will run in the next admin user session." -ForegroundColor Green
     Write-Log "Triggered $TaskPath$TaskName."
 } catch {
     Write-Log "ERROR: Failed to trigger $TaskPath$TaskName - $_"


### PR DESCRIPTION
PR #229 introduced em-dashes (U+2014) in comments and one Write-Host string. PowerShell 5 reads .ps1 files without a UTF-8 BOM as Windows-1252 by default; the em-dash bytes get misread, breaking string termination:

\`\`\`
The string is missing the terminator: ".
\`\`\`

Fix: replace every em-dash with a regular ASCII hyphen. Pure ASCII parses identically in any codepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)