### PR TITLE
Re-open RDP + SSH on GFC-SERVER-01 after HSS baseline (server-scoped)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,17 @@ HSS is a Microsoft Store app and can't be installed under SYSTEM (winget msstore
 
 Verify install state on an endpoint with `Get-AppxPackage -AllUsers VioletHansen.HardenSystemSecurity`. If empty, the user-logon task hasn't fired yet — see [Ensure-Apps.ps1](Ensure-Apps.ps1) for the bootstrap path.
 
+### Remote-access override (scoped to named hosts only)
+
+The MS Security Baseline in the report sets `SeDenyNetworkLogonRight = *S-1-5-113` ("Deny access to this computer from the network" for all **local** accounts). With NLA on, RDP does a Type 3 network logon during pre-auth, so local-account RDP fails with `0x1307` / `STATUS_LOGON_TYPE_NOT_GRANTED` — and Windows OpenSSH (also a network logon) would fail identically. HSS ships no override for this specific right.
+
+`Set-RemoteAccessOverride` in the apply-task payload ([Ensure-Apps.ps1](Ensure-Apps.ps1)) re-opens access **after** `ImportReport` (so it always wins over the freshly-applied baseline) and on the hash-match no-op path (so steady-state machines keep it). It is **scoped to the `$sshHosts` list** (currently just `GFC-SERVER-01`):
+
+- **Listed hosts:** enable RDP (`fDenyTSConnections=0`) and relax `SeDenyNetworkLogonRight` to Guests-only via `secedit`, enabling OpenSSH and RDP-with-NLA. **NLA stays on.**
+- **Every other endpoint:** the function returns immediately — left completely untouched and fully hardened (no RDP change, no NLA change). This is deliberate: local-account RDP requires dropping either NLA or the network-logon deny, so the relaxation is confined to the one box that needs SSH. Add a hostname to `$sshHosts` to extend it to another box.
+
+Do **not** move this logic into a customize `includes/` script — the HSS apply runs asynchronously in a scheduled task, so an include would race it and get clobbered when the baseline re-applies.
+
 ## Per-run sentinel pattern for machine-wide includes
 
 The orchestrator iterates every include once per loaded user hive (typically 3×: current user, default template, signed-in user). Includes that only write to HKLM or otherwise machine-wide state should guard with `Test-MachineWideSentinel` from [includes/Shared-Functions.ps1](includes/Shared-Functions.ps1):

--- a/Ensure-Apps.ps1
+++ b/Ensure-Apps.ps1
@@ -217,6 +217,48 @@ function SetState($name, $value, $type = 'String') {
     New-ItemProperty -Path $stateKey -Name $name -Value $value -PropertyType $type -Force | Out-Null
 }
 
+function Set-RemoteAccessOverride {
+    # The HSS Microsoft Security Baseline applies "Deny access to this computer
+    # from the network" (SeDenyNetworkLogonRight = Local account / *S-1-5-113).
+    # That denies local accounts any network-class (Type 3) logon. With NLA on,
+    # RDP performs exactly that during pre-auth, so local-account RDP fails with
+    # 0x1307 / STATUS_LOGON_TYPE_NOT_GRANTED - and Windows OpenSSH (also a
+    # network logon) would fail the same way. HSS exposes no override for it.
+    #
+    # SCOPED TO NAMED HOSTS ONLY. On a listed host we relax the network-logon
+    # right to Guests-only (drop the local-account deny) so OpenSSH and
+    # RDP-with-NLA both work; NLA stays ON. Every other endpoint is left
+    # completely untouched and fully hardened - no RDP change, no NLA change.
+    # Runs AFTER ImportReport so it wins over the freshly-applied baseline; it
+    # is idempotent.
+    $sshHosts = @('GFC-SERVER-01')
+    if ($env:COMPUTERNAME -notin $sshHosts) { return }
+
+    $tsRoot = 'HKLM:\System\CurrentControlSet\Control\Terminal Server'
+    try {
+        Set-ItemProperty -Path $tsRoot -Name 'fDenyTSConnections' -Value 0 -Type DWord -Force
+    } catch { Log "RemoteAccess override: could not enable RDP (fDenyTSConnections) - $_" }
+
+    $infLines = @(
+        '[Unicode]'
+        'Unicode=yes'
+        '[Version]'
+        'signature="$CHICAGO$"'
+        'Revision=1'
+        '[Privilege Rights]'
+        'SeDenyNetworkLogonRight = *S-1-5-32-546'
+    )
+    $infPath = Join-Path $env:TEMP 'cws-net-logon.inf'
+    $dbPath  = Join-Path $env:TEMP 'cws-net-logon.sdb'
+    try {
+        Set-Content -LiteralPath $infPath -Value $infLines -Encoding Unicode -Force
+        $null = & secedit.exe /configure /db $dbPath /cfg $infPath /areas USER_RIGHTS
+        SetState 'RemoteAccessOverride'    'network-logon-relaxed'
+        SetState 'RemoteAccessOverrideUtc' (Get-Date).ToUniversalTime().ToString('o')
+        Log "RemoteAccess override: SeDenyNetworkLogonRight relaxed to Guests-only ($env:COMPUTERNAME)."
+    } catch { Log "RemoteAccess override FAILED - $_" }
+}
+
 Log "Apply task fired."
 
 if (-not (Test-Path -LiteralPath $report)) {
@@ -229,7 +271,8 @@ $storedHash  = (Get-ItemProperty -Path $stateKey -Name 'ReportHash' -ErrorAction
 $storedStat  = (Get-ItemProperty -Path $stateKey -Name 'LastAppliedStatus' -ErrorAction SilentlyContinue).LastAppliedStatus
 
 if ($currentHash -eq $storedHash -and $storedStat -eq 'success') {
-    Log "Hash matches ($($currentHash.Substring(0,12))...) and last status is success; skip."
+    Log "Hash matches ($($currentHash.Substring(0,12))...) and last status is success; skip ImportReport."
+    Set-RemoteAccessOverride
     return
 }
 
@@ -283,6 +326,10 @@ if ($exit -eq 0) {
     SetState 'LastAppliedStatus' 'failed'
     Log "Apply failed (exit $exit)."
 }
+
+# Re-open remote access AFTER ImportReport so it wins over the freshly-applied
+# baseline (runs on both success and failure paths).
+Set-RemoteAccessOverride
 '@
 
     $payloadDir  = Join-Path $env:ProgramData 'CustomizeWindowsSetup'


### PR DESCRIPTION
## Problem

After the HSS Microsoft Security Baseline applies, RDP into `GFC-SERVER-01` fails with **`0x1307` / `STATUS_LOGON_TYPE_NOT_GRANTED`**, and Windows OpenSSH would fail the same way.

Root cause (confirmed live on the server via `secedit` export + Event 4625 showing **Logon Type 3 / `0xC000015B`**):
- The baseline sets `SeDenyNetworkLogonRight = *S-1-5-113` ("Deny access to this computer from the network" for **all local accounts**).
- With **NLA on**, RDP performs a Type 3 *network* logon during pre-auth → denied for the local `GF Administrator` account.
- The HSS app's "Allow signing in through Remote Desktop Services" override targets a *different* right (`SeDenyRemoteInteractiveLogonRight`) and does **not** fix this. HotCakeX ships no override for the network-logon right ([wiki](https://github.com/HotCakeX/Harden-Windows-Security/wiki/Overrides-for-Microsoft-Security-Baseline); see issues [#869](https://github.com/HotCakeX/Harden-Windows-Security/issues/869), [#97](https://github.com/HotCakeX/Harden-Windows-Security/issues/97)).

The fix was validated live: relaxing `SeDenyNetworkLogonRight` to Guests-only restored RDP immediately.

## Change

`Set-RemoteAccessOverride` is added to the HSS apply-task payload in `Ensure-Apps.ps1`. It runs **after `ImportReport`** (and on the hash-match no-op path) so it always wins over the freshly-applied baseline, and is **scoped to a hostname allow-list** (`$sshHosts`, currently just `GFC-SERVER-01`):

- **Listed hosts:** enable RDP (`fDenyTSConnections=0`) + relax `SeDenyNetworkLogonRight` to Guests-only (`*S-1-5-32-546`) via `secedit`. Enables OpenSSH and RDP-with-NLA. **NLA stays on.**
- **Every other endpoint:** returns immediately — left completely untouched and fully hardened (no RDP change, no NLA change).

## Why server-scoped

Local-account RDP can't keep *both* NLA and the network-logon deny — one must go. Rather than weaken the whole fleet, the relaxation is confined to the single box that needs SSH. Add a hostname to `$sshHosts` to extend it.

## Notes

- Report JSON is left untouched (treated as an opaque export per `CLAUDE.md`).
- Not implemented as a customize `includes/` script on purpose: HSS applies asynchronously via a scheduled task, so an include would race it and get clobbered.
- No automated tests (per `AGENTS.md`); validated manually on `GFC-SERVER-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)