### PR TITLE
Keep servers off File and Printer Sharing in Join-Workgroup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,8 @@ The MS Security Baseline in the report sets `SeDenyNetworkLogonRight = *S-1-5-11
 
 Do **not** move this logic into a customize `includes/` script — the HSS apply runs asynchronously in a scheduled task, so an include would race it and get clobbered when the baseline re-applies.
 
+**Related server carve-out:** [includes/Join-Workgroup.ps1](includes/Join-Workgroup.ps1) enables File and Printer Sharing / Network Discovery for pharmacy workstation LANs, but **disables** them for hosts in its own `$noFileSharingHosts` list (the servers) — because the network-logon relaxation above makes inbound SMB on those boxes a lateral-movement surface. Keep `$noFileSharingHosts` in sync with `$sshHosts` in [Ensure-Apps.ps1](Ensure-Apps.ps1): a host that gets SSH should also be kept off file sharing.
+
 ## Per-run sentinel pattern for machine-wide includes
 
 The orchestrator iterates every include once per loaded user hive (typically 3×: current user, default template, signed-in user). Includes that only write to HKLM or otherwise machine-wide state should guard with `Test-MachineWideSentinel` from [includes/Shared-Functions.ps1](includes/Shared-Functions.ps1):

--- a/includes/Join-Workgroup.ps1
+++ b/includes/Join-Workgroup.ps1
@@ -4,6 +4,27 @@ if (Test-MachineWideSentinel -Name 'Join-Workgroup') { return }
 $CurrentWorkgroup = (Get-WmiObject Win32_ComputerSystem).Workgroup
 $WORKGROUP = 'MYLOCALCHEMIST'
 
+# File and Printer Sharing / Network Discovery below is for pharmacy workstation
+# LANs - peer-to-peer sharing within a branch. Servers must NOT expose it:
+# GFC-SERVER-01 is administered remotely over the cloudflared tunnel, has its
+# network-logon right relaxed for SSH (see Ensure-Apps.ps1), and serves no
+# shares - so inbound SMB/NetBIOS there is pure lateral-movement surface. For
+# those hosts we DISABLE sharing on every run instead of enabling it. Keep this
+# list in sync with $sshHosts in Ensure-Apps.ps1.
+$noFileSharingHosts = @('GFC-SERVER-01')
+
+if ($env:COMPUTERNAME -in $noFileSharingHosts) {
+    Write-Host ($CR + "Server host '$env:COMPUTERNAME' - disabling File and Printer Sharing / Network Discovery") -foregroundcolor $FOREGROUNDCOLOR
+    if ($CurrentWorkgroup -ne $WORKGROUP) {
+        Try { Add-Computer -WorkgroupName $WORKGROUP -ErrorAction Stop } Catch { Write-Warning $Error[0] }
+    }
+    foreach ($grp in 'File and Printer Sharing', 'Network Discovery') {
+        Disable-NetFirewallRule -DisplayGroup $grp -ErrorAction SilentlyContinue
+    }
+    Write-Log "Server host $env:COMPUTERNAME: File and Printer Sharing + Network Discovery disabled (not a P2P sharing node)"
+    return
+}
+
 Write-Host ($CR + "Current workgroup: $CurrentWorkgroup") -foregroundcolor $FOREGROUNDCOLOR
 
 if ($CurrentWorkgroup -eq $WORKGROUP) {


### PR DESCRIPTION
## Why

[includes/Join-Workgroup.ps1](includes/Join-Workgroup.ps1) enables **File and Printer Sharing** + **Network Discovery** so pharmacy workstations can share within a branch LAN. On `GFC-SERVER-01` that's unwanted and actively risky:

- It's administered remotely over the cloudflared tunnel (SSH/RDP on loopback), not via the LAN.
- Its `SeDenyNetworkLogonRight` is relaxed for SSH (PR #231), so local accounts *can* complete network logons there.
- It serves **no** SMB shares (only the built-in admin shares; no custom shares, no active sessions; workgroup-joined).

So inbound SMB/NetBIOS on that box is pure lateral-movement surface — a LAN host with a local-account credential could reach `\\GFC-SERVER-01\C$`.

Today the box happens to be spared only because it's *already* in the workgroup, so Join-Workgroup early-returns and skips the enable. That's accidental — a re-image or re-join would silently reopen SMB.

## Change

Add a `$noFileSharingHosts` allow-list. For hosts on it, the script **disables** File and Printer Sharing + Network Discovery on **every run** (not gated behind the workgroup-join early-return) and returns early, rather than enabling them. Workstations are completely unchanged.

Mirrors the host-scoped pattern from `Ensure-Apps.ps1` (`$sshHosts`); CLAUDE.md notes the two lists should stay in sync.

## Testing

No automated tests (per AGENTS.md). On `GFC-SERVER-01` a customize run will now leave `Get-NetFirewallRule -DisplayGroup 'File and Printer Sharing' -Direction Inbound` all `Enabled: False`; on a workstation the rules remain enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)